### PR TITLE
Migrate to Python 3 and add 35 new conference scrapers (214k papers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+pubs_nips
+temp.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__/
-pubs_nips
+pubs_*
 temp.pdf

--- a/README
+++ b/README
@@ -18,27 +18,45 @@ AVAILABLE CONFERENCES
 -------------------------------------------------------------------------------
 Run any scraper to generate its pickle database:
 
-  Scraper                      Conference   Source                      Years       Papers
-  -------------------------    ---------    -------------------------   ----------  ------
-  nips_download_parse.py       NeurIPS      proceedings.neurips.cc      2006-2024   21,859
-  acl_download_parse.py        ACL          aclanthology.org            2000-2025   21,490
-  emnlp_download_parse.py      EMNLP        aclanthology.org            2000-2025   20,646
-  cvpr_download_parse.py       CVPR         openaccess.thecvf.com       2013-2025   18,452
-  aaai_download_parse.py       AAAI         ojs.aaai.org                2019-2025   15,097
-  icml_download_parse.py       ICML         proceedings.mlr.press       2013-2025   14,281
-  ijcai_download_parse.py      IJCAI        ijcai.org                   2013-2025    9,940
-  iccv_download_parse.py       ICCV         openaccess.thecvf.com       2013-2025    9,145
-  naacl_download_parse.py      NAACL        aclanthology.org            2000-2025    8,925
-  coling_download_parse.py     COLING       aclanthology.org            2000-2025    8,740
-  eccv_download_parse.py       ECCV         ecva.net                    2018-2024    6,166
-  aistats_download_parse.py    AISTATS      proceedings.mlr.press       2010-2025    4,613
-  wacv_download_parse.py       WACV         openaccess.thecvf.com       2020-2026    4,435
-  eacl_download_parse.py       EACL         aclanthology.org            2003-2024    3,138
-  colt_download_parse.py       COLT         proceedings.mlr.press       2011-2025    1,598
-  corl_download_parse.py       CoRL         proceedings.mlr.press       2017-2025    1,490
-  uai_download_parse.py        UAI          proceedings.mlr.press       2019-2025    1,368
-  alt_download_parse.py        ALT          proceedings.mlr.press       2017-2025      381
-                                                                        TOTAL     171,764
+  Scraper                        Conference    Source                      Years       Papers
+  ----------------------------   -----------   -------------------------   ---------   ------
+  nips_download_parse.py         NeurIPS       proceedings.neurips.cc      2006-2024   21,859
+  acl_download_parse.py          ACL           aclanthology.org            2000-2025   21,490
+  emnlp_download_parse.py        EMNLP         aclanthology.org            2000-2025   20,646
+  cvpr_download_parse.py         CVPR          openaccess.thecvf.com       2013-2025   18,452
+  aaai_download_parse.py         AAAI          ojs.aaai.org                2019-2025   15,097
+  icml_download_parse.py         ICML          proceedings.mlr.press       2013-2025   14,281
+  iclr_download_parse.py         ICLR          openreview.net              2018-2025   11,015
+  ijcai_download_parse.py        IJCAI         ijcai.org                   2013-2025    9,940
+  iccv_download_parse.py         ICCV          openaccess.thecvf.com       2013-2025    9,145
+  naacl_download_parse.py        NAACL         aclanthology.org            2000-2025    8,925
+  interspeech_download_parse.py  INTERSPEECH   isca-archive.org            2016-2024    8,785
+  coling_download_parse.py       COLING        aclanthology.org            2000-2025    8,740
+  eccv_download_parse.py         ECCV          ecva.net                    2018-2024    6,166
+  ijcnlp_download_parse.py      IJCNLP        aclanthology.org            2005-2025    5,337
+  aistats_download_parse.py      AISTATS       proceedings.mlr.press       2010-2025    4,613
+  wacv_download_parse.py         WACV          openaccess.thecvf.com       2020-2026    4,435
+  jmlr_download_parse.py         JMLR          jmlr.org                    2000-2025    4,135
+  semeval_download_parse.py      SemEval       aclanthology.org            2007-2025    3,217
+  eacl_download_parse.py         EACL          aclanthology.org            2003-2024    3,138
+  miccai_download_parse.py       MICCAI        papers.miccai.org           2024-2025    1,883
+  colt_download_parse.py         COLT          proceedings.mlr.press       2011-2025    1,598
+  conll_download_parse.py        CoNLL         aclanthology.org            2000-2025    1,547
+  corl_download_parse.py         CoRL          proceedings.mlr.press       2017-2025    1,490
+  rss_download_parse.py          RSS           roboticsproceedings.org     2005-2025    1,469
+  uai_download_parse.py          UAI           proceedings.mlr.press       2019-2025    1,368
+  aacl_download_parse.py         AACL          aclanthology.org            2020-2025      938
+  acml_download_parse.py         ACML          proceedings.mlr.press       2010-2024      834
+  nsdi_download_parse.py         NSDI          usenix.org                  2012-2025      821
+  l4dc_download_parse.py         L4DC          proceedings.mlr.press       2020-2025      669
+  midl_download_parse.py         MIDL          proceedings.mlr.press       2019-2024      504
+  osdi_download_parse.py         OSDI          usenix.org                  2012-2025      472
+  alt_download_parse.py          ALT           proceedings.mlr.press       2017-2025      381
+  mlhc_download_parse.py         MLHC          proceedings.mlr.press       2016-2025      323
+  pgm_download_parse.py          PGM           proceedings.mlr.press       2016-2024      222
+  clear_download_parse.py        CLeaR         proceedings.mlr.press       2022-2025      190
+  automl_download_parse.py       AutoML        proceedings.mlr.press       2016-2025       97
+                                                                           TOTAL      214,222
 
 -------------------------------------------------------------------------------
 USAGE

--- a/README
+++ b/README
@@ -1,22 +1,51 @@
 REsearch POOLer (repool)
-Originally by Andrej Karpathy, migrated to Python 3 and extended.
+Project site: https://sites.google.com/site/researchpooler/home
+
+Authors: Andrej Karpathy <karpathy@cs.stanford.edu> || <andrej.karpathy@gmail.com>, http://cs.stanford.edu/~karpathy/
 
 -------------------------------------------------------------------------------
-MOTIVATION
+MOTIVATION AND PLAN
 -------------------------------------------------------------------------------
-Literature review is much harder than it should be. This set of tools scrapes
-proceedings from major AI/ML/NLP/CV conferences and lets you query them with
-simple Python list comprehensions.
+- Ever wish you could right away view all papers published based on a keyword in title or abstract?
+- Or, ever wish you could look up the most similar paper (content wise) to some paper on some random url?
+- How about searching for all papers that report a result on a particular dataset?
+-> Literature review is much harder than it should be.
+
+This set of tools is an initiative to fix this problem. Here's the master plan and types of scripts in this project:
+
+STAGE 1 scripts: scripts for raw data gathering and parsing that output pickles in an intermediate dictionary-based representation. These will include mostly scripts that download files, parse HTML, etc.
+STAGE 2 scripts: scripts that enrich the intermediate representations from STAGE 1 in various ways. For example, a script could iterate over publications in database, and if it finds that some entry is missing its pdf contents, it could attempt a google search to find the pdf, and add it if successful.
+STAGE 3 scripts: tools and helper functions that can analyze the intermediate representations and produce higher level scripts that do more interesting things. For example, functionality such as 'find all documents that are similar to this one', or 'find object detection papers in psychology'. All kinds of fun Machine Learning can go here as well, like LDA etc.
+STAGE 4 files: create nice web-based UI (maybe using Google App Engine?) to make the project accessible and easy to use. These will be modules that interact with STAGE 3 scripts on the backend.
 
 -------------------------------------------------------------------------------
 INSTALLATION
 -------------------------------------------------------------------------------
 pip install -r requirements.txt
 
+Then run any scraper to generate its database:
+$> python nips_download_parse.py
+$> python nips_add_pdftext.py
+
 -------------------------------------------------------------------------------
-AVAILABLE CONFERENCES
+EXAMPLE USAGE
 -------------------------------------------------------------------------------
-Run any scraper to generate its pickle database:
+Say you unexpectedly became very interested in Deep Belief Networks. It now takes 3 lines of python to open all NIPS papers that mention 'deep' in title inside your browser: (also see demo2)
+
+>>> pubs = loadPubs('pubs_nips')
+>>> p = [x['pdf'] for x in pubs if 'deep' in x['title'].lower()]
+>>> openPDFs(p)
+
+Or maybe you want to open all papers that mention MNIST dataset? (demo1 also shows how you can easily go on to open the 3 latest ones.)
+>>> pubs = loadPubs('pubs_nips')
+>>> p = [x['title'] for x in pubs if 'mnist' in x.get('pdf_text',{})]
+>>> openPDFs(p)
+
+Or how about opening papers that are most similar to some paper at some url? See demo3.
+
+-------------------------------------------------------------------------------
+AVAILABLE CONFERENCES (36 scrapers, 214,222 papers)
+-------------------------------------------------------------------------------
 
   Scraper                        Conference    Source                      Years       Papers
   ----------------------------   -----------   -------------------------   ---------   ------
@@ -90,6 +119,25 @@ USAGE
    See demo3.py for an example using bag-of-words similarity.
 
 -------------------------------------------------------------------------------
+ORGANIZATION, I/O AND DATA REPRESENTATIONS
+-------------------------------------------------------------------------------
+
+Here's the idea for the near future, I think: there will be several stage1 scripts, each of which is reponsible for parsing a particular venue of publications. For example, the stage1 script nips_download_parse.py parses and outputs all publications in NIPS from 2003 to 2011. (but does not analyze the text)
+
+The idea is to have very similar scripts for other venues, such as ICML, or CVPR, etc... The output of each such script should be a pickled list of dictionaries. Each dictionary represents a publication. For example:
+[{'title': 'Solving AI using Random Forests', 'authors': ['Jim Smith', 'Bill Smith', 'year': 2020, 'venue': 'NIPS 2020', 'pdf': 'http://google.com/ai'},
+...]
+
+this representation is a flexible start, as some conference pages provide more information than others, and we don't want to force any particular structure from the get go. In other words, the database could contain some papers that have the author, title, and abstract, but not the full text. Another entry might have the full text, but maybe it is missing author or title. Stage 2 scripts will be useful to go over these representations, and fill in details in whatever ways possible. (such as maybe hooking into other sites like Google Scholar, etc?)
+
+Note: I am well aware that the "flat list of dictionaries pickled in a file" representation isn't scalable. However, I am a believer of avoiding premature encapsulation. Goal is to keep things as flat as possible, as long as possible, and to avoid immediate over-engineering of things.
+
+Lastly, this representation is actually kinda neat because it lets you run all kinds of nice queries very quickly using list comprehensions. For example:
+
+#all papers by Andrew Ng
+>>> [x['title'] for x in pubs if any("A. Ng" in a for a in x['authors'])]
+
+-------------------------------------------------------------------------------
 PIPELINE
 -------------------------------------------------------------------------------
 STAGE 1: Scrapers (*_download_parse.py) fetch proceedings and save as pickles.
@@ -97,17 +145,28 @@ STAGE 2: nips_add_pdftext.py downloads PDFs and extracts bag-of-words text.
 STAGE 3: repool_analysis.py provides similarity search across publications.
 
 -------------------------------------------------------------------------------
-DATA FORMAT
+FAQ
 -------------------------------------------------------------------------------
-Each scraper outputs a pickled list of dictionaries. Each dict has:
+Q: Your file x does this, but that's bad practice, and you want to do y. Also you have a bug in z.
+A: Most likely agreed. These scripts/functions are something I hacked together in 3 days during periods of about 1am to 6am. I'd be happy to hear thoughs/suggestions or see fixes or better/alternative ways of doing things. Check the website for this project, which comes with discussion forum attached.
 
-  {'title': 'Paper Title',
-   'authors': ['Author One', 'Author Two'],
-   'venue': 'NeurIPS 2024',
-   'year': 2024,
-   'pdf': 'https://...'}
+-------------------------------------------------------------------------------
+MANPOWER ADVERTISEMENTS / IDEAS
+-------------------------------------------------------------------------------
+Advertisement posting 1:
+1. Pick your favorite conference/journal
+2. Look through their page and write an HTML parser in style of my nips_download_parse.py
+3. Output the same type of representation as described above in  a file 'pubs_conferenceblah'
+4. Publish the scripts you used so that it is faster for others to do similar things
+5. Upload your output pubs_ file, or send it to me for publishing
 
-Optionally after stage 2: 'pdf_text' contains a bag-of-words dict.
+Advertisement posting 2:
+It should be possible to take arbitrary directory full of PDF files, and create pubs_ file for them. Can Title, Authors be reliably extracted from PDFs somehow? Can tools be made that at least partially automate the process so that different parsers don't have to be written for each venue? Can we find large databases of papers/information online that we can scrape and enter?
+
+Advertisement posting 3:
+Heavy duty Machine Learning tools (such as Naive Bayes, lol) needed that can work on top of representations stored in pubs_ files and answer questions such as: 'what papers in database are most similar to the one on this url?', or, 'What are the common topics?'
+
+etc etc...
 
 -------------------------------------------------------------------------------
 DEPENDENCIES

--- a/README
+++ b/README
@@ -1,96 +1,98 @@
-REsearch POOLer (repool) 
-Project site: https://sites.google.com/site/researchpooler/home
-
-Authors: Andrej Karpathy <karpathy@cs.stanford.edu> || <andrej.karpathy@gmail.com>, http://cs.stanford.edu/~karpathy/
+REsearch POOLer (repool)
+Originally by Andrej Karpathy, migrated to Python 3 and extended.
 
 -------------------------------------------------------------------------------
-MOTIVATION AND PLAN
+MOTIVATION
 -------------------------------------------------------------------------------
-- Ever wish you could right away view all papers published based on a keyword in title or abstract?
-- Or, ever wish you could look up the most similar paper (content wise) to some paper on some random url?
-- How about searching for all papers that report a result on a particular dataset?
--> Literature review is much harder than it should be.
-
-This set of tools is an initiative to fix this problem. Here's the master plan and types of scripts in this project:
-
-STAGE 1 scripts: scripts for raw data gathering and parsing that output pickles in an intermediate dictionary-based representation. These will include mostly scripts that download files, parse HTML, etc.
-STAGE 2 scripts: scripts that enrich the intermediate representations from STAGE 1 in various ways. For example, a script could iterate over publications in database, and if it finds that some entry is missing its pdf contents, it could attempt a google search to find the pdf, and add it if successful.
-STAGE 3 scripts: tools and helper functions that can analyze the intermediate representations and produce higher level scripts that do more interesting things. For example, functionality such as 'find all documents that are similar to this one', or 'find object detection papers in psychology'. All kinds of fun Machine Learning can go here as well, like LDA etc.
-STAGE 4 files: create nice web-based UI (maybe using Google App Engine?) to make the project accessible and easy to use. These will be modules that interact with STAGE 3 scripts on the backend.
+Literature review is much harder than it should be. This set of tools scrapes
+proceedings from major AI/ML/NLP/CV conferences and lets you query them with
+simple Python list comprehensions.
 
 -------------------------------------------------------------------------------
 INSTALLATION
 -------------------------------------------------------------------------------
-1. Download pubs_nips from the site[*] (https://sites.google.com/site/researchpooler/downloads)
-2. Browse around (project is young, no installation needed so far!)
-3. Download/Install current Python dependencies:
-
-BeautifulSoup   [for easy and robust HTML parsing]
-PDFMiner        [for parsing PDFs and extracting text]
-simplejson      [OPTIONAL. for parsing outputs of Google searches using their API]
-
-4. Enjoy the demos
-
-[*] Instead of downloading the database you can also regenerate the pubs_nips database yourself using the two scripts I wrote. Simply run:
-$> python nips_download_parse.py
-(takes a few seconds) and then
-$> python nips_add_pdftext.py
-(takes potentially an hour or two because it has to download and parse all papers published at NIPS since 2003)
--------------------------------------------------------------------------------
-EXAMPLE USAGE
--------------------------------------------------------------------------------
-Say you unexpectedly became very interested in Deep Belief Networks. It now takes 3 lines of python to open all NIPS papers that mention 'deep' in title inside your browser: (also see demo2)
-
->>> pubs = loadPubs('pubs_nips')
->>> p = [x['pdf'] for x in pubs if 'deep' in x['title'].lower()]
->>> openPDFs(p)
-
-Or maybe you want to open all papers that mention MNIST dataset? (demo1 also shows how you can easily go on to open the 3 latest ones.)
->>> pubs = loadPubs('pubs_nips')
->>> p = [x['title'] for x in pubs if 'mnist' in x.get('pdf_text',{})]
->>> openPDFs(p)
-
-Or how about opening papers that are most similar to some paper at some url? See demo3.
+pip install -r requirements.txt
 
 -------------------------------------------------------------------------------
-ORGANIZATION, I/O AND DATA REPRESENTATIONS
+AVAILABLE CONFERENCES
 -------------------------------------------------------------------------------
+Run any scraper to generate its pickle database:
 
-Here's the idea for the near future, I think: there will be several stage1 scripts, each of which is reponsible for parsing a particular venue of publications. For example, the stage1 script nips_download_parse.py parses and outputs all publications in NIPS from 2003 to 2011. (but does not analyze the text)
-
-The idea is to have very similar scripts for other venues, such as ICML, or CVPR, etc... The output of each such script should be a pickled list of dictionaries. Each dictionary represents a publication. For example:
-[{'title': 'Solving AI using Random Forests', 'authors': ['Jim Smith', 'Bill Smith', 'year': 2020, 'venue': 'NIPS 2020', 'pdf': 'http://google.com/ai'}, 
-...]
-
-this representation is a flexible start, as some conference pages provide more information than others, and we don't want to force any particular structure from the get go. In other words, the database could contain some papers that have the author, title, and abstract, but not the full text. Another entry might have the full text, but maybe it is missing author or title. Stage 2 scripts will be useful to go over these representations, and fill in details in whatever ways possible. (such as maybe hooking into other sites like Google Scholar, etc?) 
-
-Note: I am well aware that the "flat list of dictionaries pickled in a file" representation isn't scalable. However, I am a believer of avoiding premature encapsulation. Goal is to keep things as flat as possible, as long as possible, and to avoid immediate over-engineering of things.
-
-Lastly, this representation is actually kinda neat because it lets you run all kinds of nice queries very quickly using list comprehensions. For example:
-
-#all papers by Andrew Ng
->>> [x['title'] for x in pubs if any("A. Ng" in a for a in x['authors'])]
+  Scraper                      Conference   Source                      Years       Papers
+  -------------------------    ---------    -------------------------   ----------  ------
+  nips_download_parse.py       NeurIPS      proceedings.neurips.cc      2006-2024   21,859
+  acl_download_parse.py        ACL          aclanthology.org            2000-2025   21,490
+  emnlp_download_parse.py      EMNLP        aclanthology.org            2000-2025   20,646
+  cvpr_download_parse.py       CVPR         openaccess.thecvf.com       2013-2025   18,452
+  aaai_download_parse.py       AAAI         ojs.aaai.org                2019-2025   15,097
+  icml_download_parse.py       ICML         proceedings.mlr.press       2013-2025   14,281
+  ijcai_download_parse.py      IJCAI        ijcai.org                   2013-2025    9,940
+  iccv_download_parse.py       ICCV         openaccess.thecvf.com       2013-2025    9,145
+  naacl_download_parse.py      NAACL        aclanthology.org            2000-2025    8,925
+  coling_download_parse.py     COLING       aclanthology.org            2000-2025    8,740
+  eccv_download_parse.py       ECCV         ecva.net                    2018-2024    6,166
+  aistats_download_parse.py    AISTATS      proceedings.mlr.press       2010-2025    4,613
+  wacv_download_parse.py       WACV         openaccess.thecvf.com       2020-2026    4,435
+  eacl_download_parse.py       EACL         aclanthology.org            2003-2024    3,138
+  colt_download_parse.py       COLT         proceedings.mlr.press       2011-2025    1,598
+  corl_download_parse.py       CoRL         proceedings.mlr.press       2017-2025    1,490
+  uai_download_parse.py        UAI          proceedings.mlr.press       2019-2025    1,368
+  alt_download_parse.py        ALT          proceedings.mlr.press       2017-2025      381
+                                                                        TOTAL     171,764
 
 -------------------------------------------------------------------------------
-FAQ
+USAGE
 -------------------------------------------------------------------------------
-Q: Your file x does this, but that's bad practice, and you want to do y. Also you have a bug in z.
-A: Most likely agreed. These scripts/functions are something I hacked together in 3 days during periods of about 1am to 6am. I'd be happy to hear thoughs/suggestions or see fixes or better/alternative ways of doing things. Check the website for this project, which comes with discussion forum attached.
+1. Generate a database by running a scraper:
+
+   python nips_download_parse.py
+
+2. Query it in Python:
+
+   from repool_util import loadPubs, openPDFs
+
+   pubs = loadPubs('pubs_nips')
+
+   # all papers with "transformer" in title
+   [x['title'] for x in pubs if 'transformer' in x['title'].lower()]
+
+   # all papers by a specific author
+   [x['title'] for x in pubs if any("Hinton" in a for a in x.get('authors',[]))]
+
+   # open PDFs of papers with "deep" in title
+   p = [x['pdf'] for x in pubs if 'deep' in x['title'].lower()]
+   openPDFs(p[:5])
+
+3. Optionally enrich with full text (downloads PDFs, takes a while):
+
+   python nips_add_pdftext.py
+
+4. Find similar papers (stage 3):
+
+   See demo3.py for an example using bag-of-words similarity.
 
 -------------------------------------------------------------------------------
-MANPOWER ADVERTISEMENTS / IDEAS
+PIPELINE
 -------------------------------------------------------------------------------
-Advertisement posting 1:
-1. Pick your favorite conference/journal
-2. Look through their page and write an HTML parser in style of my nips_download_parse.py
-3. Output the same type of representation as described above in  a file 'pubs_conferenceblah'
-4. Publish the scripts you used so that it is faster for others to do similar things
-5. Upload your output pubs_ file, or send it to me for publishing
+STAGE 1: Scrapers (*_download_parse.py) fetch proceedings and save as pickles.
+STAGE 2: nips_add_pdftext.py downloads PDFs and extracts bag-of-words text.
+STAGE 3: repool_analysis.py provides similarity search across publications.
 
-Advertisement posting 2:
-It should be possible to take arbitrary directory full of PDF files, and create pubs_ file for them. Can Title, Authors be reliably extracted from PDFs somehow? Can tools be made that at least partially automate the process so that different parsers don't have to be written for each venue? Can we find large databases of papers/information online that we can scrape and enter?
+-------------------------------------------------------------------------------
+DATA FORMAT
+-------------------------------------------------------------------------------
+Each scraper outputs a pickled list of dictionaries. Each dict has:
 
-Advertisement posting 3:
-Heavy duty Machine Learning tools (such as Naive Bayes, lol) needed that can work on top of representations stored in pubs_ files and answer questions such as: 'what papers in database are most similar to the one on this url?', or, 'What are the common topics?'
+  {'title': 'Paper Title',
+   'authors': ['Author One', 'Author Two'],
+   'venue': 'NeurIPS 2024',
+   'year': 2024,
+   'pdf': 'https://...'}
 
-etc etc...
+Optionally after stage 2: 'pdf_text' contains a bag-of-words dict.
+
+-------------------------------------------------------------------------------
+DEPENDENCIES
+-------------------------------------------------------------------------------
+beautifulsoup4    HTML parsing
+pdfminer.six      PDF text extraction (for stage 2)

--- a/aaai_download_parse.py
+++ b/aaai_download_parse.py
@@ -1,0 +1,111 @@
+"""
+Standalone helper script.
+
+Parses AAAI proceedings from ojs.aaai.org, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle called pubs_aaai.
+"""
+
+import urllib.request
+import re
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://ojs.aaai.org/index.php/AAAI"
+
+
+def fetch(url):
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urllib.request.urlopen(req) as f:
+        return f.read().decode('utf-8')
+
+
+# Step 1: collect all issue URLs from archive pages
+print("collecting issue list from archive...")
+issue_urls = {}  # year -> list of (url, title)
+
+for page in range(1, 15):
+    url = "%s/issue/archive/%d" % (BASE_URL, page)
+    try:
+        html = fetch(url)
+    except:
+        break
+
+    soup = BeautifulSoup(html, 'html.parser')
+    links = soup.find_all('a', class_='title')
+    if not links:
+        break
+
+    for a in links:
+        title = a.text.strip()
+        href = a.get('href', '')
+        m = re.search(r'AAAI-(\d+)', title)
+        if not m:
+            continue
+        yr = int(m.group(1))
+        year = yr + 2000 if yr < 100 else yr
+        if year not in issue_urls:
+            issue_urls[year] = []
+        issue_urls[year].append((href, title))
+
+print("found issues for years: %s" % sorted(issue_urls.keys()))
+
+# Step 2: scrape papers from each issue
+pubs = []
+warnings = []
+
+for year in sorted(issue_urls):
+    issues = issue_urls[year]
+    print("downloading AAAI %d (%d issues)..." % (year, len(issues)))
+
+    venue = 'AAAI %d' % (year,)
+    old_count = len(pubs)
+
+    for issue_url, issue_title in issues:
+        try:
+            html = fetch(issue_url)
+        except Exception as e:
+            warnings.append("error fetching %s: %s" % (issue_url, e))
+            continue
+
+        soup = BeautifulSoup(html, 'html.parser')
+
+        for article in soup.find_all('div', class_='obj_article_summary'):
+            new_pub = {}
+
+            title_tag = article.find('h3', class_='title')
+            if not title_tag:
+                continue
+            a = title_tag.find('a')
+            if not a:
+                continue
+
+            new_pub['title'] = a.text.strip()
+
+            authors_div = article.find('div', class_='authors')
+            if authors_div:
+                authors_text = authors_div.text.strip()
+                new_pub['authors'] = [x.strip() for x in authors_text.split(',')]
+
+            pdf_link = article.find('a', class_='obj_galley_link pdf')
+            if pdf_link:
+                new_pub['pdf'] = pdf_link['href']
+
+            new_pub['venue'] = venue
+            new_pub['year'] = year
+            pubs.append(new_pub)
+
+    print("read in %d publications for AAAI %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_aaai"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/aaai_download_parse.py
+++ b/aaai_download_parse.py
@@ -16,7 +16,7 @@ BASE_URL = "https://ojs.aaai.org/index.php/AAAI"
 
 def fetch(url):
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-    with urllib.request.urlopen(req) as f:
+    with urllib.request.urlopen(req, timeout=30) as f:
         return f.read().decode('utf-8')
 
 
@@ -28,7 +28,7 @@ for page in range(1, 15):
     url = "%s/issue/archive/%d" % (BASE_URL, page)
     try:
         html = fetch(url)
-    except:
+    except Exception:
         break
 
     soup = BeautifulSoup(html, 'html.parser')

--- a/aacl_download_parse.py
+++ b/aacl_download_parse.py
@@ -1,0 +1,88 @@
+"""
+Standalone helper script.
+
+Parses AACL (Asia-Pacific Chapter of the ACL) proceedings from
+aclanthology.org, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle called pubs_aacl.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://aclanthology.org"
+
+pubs = []
+warnings = []
+
+for year in range(2020, 2027):
+    url = "%s/events/aacl-%d/" % (BASE_URL, year)
+    print("downloading AACL %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'AACL %d' % (year,)
+    old_count = len(pubs)
+
+    for strong in soup.find_all('strong'):
+        a = strong.find('a', class_='align-middle')
+        if not a:
+            continue
+
+        title = a.text.strip()
+        if not title:
+            continue
+
+        # skip proceedings headers / reports
+        href = a.get('href', '')
+        if href.endswith('.0/') or 'report' in href:
+            continue
+
+        new_pub = {'title': title}
+
+        # authors are <a href="/people/..."> in the parent <span>
+        span = strong.parent
+        if span:
+            authors = []
+            for author_a in span.find_all('a'):
+                author_href = author_a.get('href', '')
+                if '/people/' in author_href:
+                    authors.append(author_a.text.strip())
+            if authors:
+                new_pub['authors'] = authors
+
+            # PDF link - look in the surrounding div
+            container = span.parent
+            if container:
+                pdf_a = container.find('a', {'title': 'Open PDF'})
+                if pdf_a:
+                    new_pub['pdf'] = pdf_a['href']
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for AACL %d." % (len(pubs) - old_count, year))
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_aacl"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/acl_download_parse.py
+++ b/acl_download_parse.py
@@ -1,0 +1,88 @@
+"""
+Standalone helper script.
+
+Parses ACL (Association for Computational Linguistics) proceedings from
+aclanthology.org, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle called pubs_acl.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://aclanthology.org"
+
+pubs = []
+warnings = []
+
+for year in range(2000, 2026):
+    url = "%s/events/acl-%d/" % (BASE_URL, year)
+    print("downloading ACL %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'ACL %d' % (year,)
+    old_count = len(pubs)
+
+    for strong in soup.find_all('strong'):
+        a = strong.find('a', class_='align-middle')
+        if not a:
+            continue
+
+        title = a.text.strip()
+        if not title:
+            continue
+
+        # skip proceedings headers / reports
+        href = a.get('href', '')
+        if href.endswith('.0/') or 'report' in href:
+            continue
+
+        new_pub = {'title': title}
+
+        # authors are <a href="/people/..."> in the parent <span>
+        span = strong.parent
+        if span:
+            authors = []
+            for author_a in span.find_all('a'):
+                author_href = author_a.get('href', '')
+                if '/people/' in author_href:
+                    authors.append(author_a.text.strip())
+            if authors:
+                new_pub['authors'] = authors
+
+            # PDF link - look in the surrounding div
+            container = span.parent
+            if container:
+                pdf_a = container.find('a', {'title': 'Open PDF'})
+                if pdf_a:
+                    new_pub['pdf'] = pdf_a['href']
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for ACL %d." % (len(pubs) - old_count, year))
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_acl"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/acml_download_parse.py
+++ b/acml_download_parse.py
@@ -1,0 +1,91 @@
+"""
+Standalone helper script.
+
+Parses ACML proceedings from proceedings.mlr.press, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_acml.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+ACML_VOLUMES = {
+    13: 2010,
+    20: 2011,
+    25: 2012,
+    29: 2013,
+    39: 2014,
+    45: 2015,
+    63: 2016,
+    77: 2017,
+    95: 2018,
+    101: 2019,
+    129: 2020,
+    157: 2021,
+    189: 2022,
+    222: 2023,
+    260: 2024,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(ACML_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading ACML %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'ACML %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for ACML %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_acml"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/aistats_download_parse.py
+++ b/aistats_download_parse.py
@@ -1,0 +1,92 @@
+"""
+Standalone helper script.
+
+Parses AISTATS proceedings from proceedings.mlr.press, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_aistats.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+AISTATS_VOLUMES = {
+    9: 2010,
+    15: 2011,
+    22: 2012,
+    31: 2013,
+    33: 2014,
+    38: 2015,
+    51: 2016,
+    54: 2017,
+    84: 2018,
+    89: 2019,
+    108: 2020,
+    130: 2021,
+    151: 2022,
+    206: 2023,
+    238: 2024,
+    258: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(AISTATS_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading AISTATS %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'AISTATS %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for AISTATS %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_aistats"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/alt_download_parse.py
+++ b/alt_download_parse.py
@@ -1,0 +1,85 @@
+"""
+Standalone helper script.
+
+Parses ALT proceedings from proceedings.mlr.press, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_alt.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+ALT_VOLUMES = {
+    76: 2017,
+    83: 2018,
+    98: 2019,
+    117: 2020,
+    132: 2021,
+    167: 2022,
+    201: 2023,
+    237: 2024,
+    272: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(ALT_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading ALT %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'ALT %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for ALT %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_alt"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/automl_download_parse.py
+++ b/automl_download_parse.py
@@ -1,0 +1,81 @@
+"""
+Standalone helper script.
+
+Parses AutoML Conference proceedings from proceedings.mlr.press, creates list
+of dictionaries that store information about each publication, and saves the
+result as a pickle in current directory called pubs_automl.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+AUTOML_VOLUMES = {
+    64: 2016,
+    188: 2022,
+    224: 2023,
+    256: 2024,
+    293: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(AUTOML_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading AutoML %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'AutoML %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for AutoML %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_automl"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/clear_download_parse.py
+++ b/clear_download_parse.py
@@ -1,0 +1,81 @@
+"""
+Standalone helper script.
+
+Parses CLeaR (Causal Learning and Reasoning) proceedings from
+proceedings.mlr.press, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle in current directory
+called pubs_clear.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+CLEAR_VOLUMES = {
+    177: 2022,
+    213: 2023,
+    236: 2024,
+    275: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(CLEAR_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading CLeaR %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'CLeaR %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for CLeaR %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_clear"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/coling_download_parse.py
+++ b/coling_download_parse.py
@@ -1,0 +1,88 @@
+"""
+Standalone helper script.
+
+Parses COLING (International Conference on Computational Linguistics) proceedings from
+aclanthology.org, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle called pubs_coling.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://aclanthology.org"
+
+pubs = []
+warnings = []
+
+for year in range(2000, 2026):
+    url = "%s/events/coling-%d/" % (BASE_URL, year)
+    print("downloading COLING %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'COLING %d' % (year,)
+    old_count = len(pubs)
+
+    for strong in soup.find_all('strong'):
+        a = strong.find('a', class_='align-middle')
+        if not a:
+            continue
+
+        title = a.text.strip()
+        if not title:
+            continue
+
+        # skip proceedings headers / reports
+        href = a.get('href', '')
+        if href.endswith('.0/') or 'report' in href:
+            continue
+
+        new_pub = {'title': title}
+
+        # authors are <a href="/people/..."> in the parent <span>
+        span = strong.parent
+        if span:
+            authors = []
+            for author_a in span.find_all('a'):
+                author_href = author_a.get('href', '')
+                if '/people/' in author_href:
+                    authors.append(author_a.text.strip())
+            if authors:
+                new_pub['authors'] = authors
+
+            # PDF link - look in the surrounding div
+            container = span.parent
+            if container:
+                pdf_a = container.find('a', {'title': 'Open PDF'})
+                if pdf_a:
+                    new_pub['pdf'] = pdf_a['href']
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for COLING %d." % (len(pubs) - old_count, year))
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_coling"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/colt_download_parse.py
+++ b/colt_download_parse.py
@@ -1,0 +1,92 @@
+"""
+Standalone helper script.
+
+Parses COLT (Conference on Learning Theory) proceedings from
+proceedings.mlr.press, creates list of dictionaries that store
+information about each publication, and saves the result as a pickle
+called pubs_colt.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+COLT_VOLUMES = {
+    19: 2011,
+    23: 2012,
+    30: 2013,
+    35: 2014,
+    40: 2015,
+    49: 2016,
+    65: 2017,
+    75: 2018,
+    99: 2019,
+    125: 2020,
+    134: 2021,
+    178: 2022,
+    195: 2023,
+    247: 2024,
+    291: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(COLT_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading COLT %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'COLT %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for COLT %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_colt"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/conll_download_parse.py
+++ b/conll_download_parse.py
@@ -1,0 +1,88 @@
+"""
+Standalone helper script.
+
+Parses CoNLL (Conference on Computational Natural Language Learning) proceedings from
+aclanthology.org, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle called pubs_conll.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://aclanthology.org"
+
+pubs = []
+warnings = []
+
+for year in range(2000, 2027):
+    url = "%s/events/conll-%d/" % (BASE_URL, year)
+    print("downloading CoNLL %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'CoNLL %d' % (year,)
+    old_count = len(pubs)
+
+    for strong in soup.find_all('strong'):
+        a = strong.find('a', class_='align-middle')
+        if not a:
+            continue
+
+        title = a.text.strip()
+        if not title:
+            continue
+
+        # skip proceedings headers / reports
+        href = a.get('href', '')
+        if href.endswith('.0/') or 'report' in href:
+            continue
+
+        new_pub = {'title': title}
+
+        # authors are <a href="/people/..."> in the parent <span>
+        span = strong.parent
+        if span:
+            authors = []
+            for author_a in span.find_all('a'):
+                author_href = author_a.get('href', '')
+                if '/people/' in author_href:
+                    authors.append(author_a.text.strip())
+            if authors:
+                new_pub['authors'] = authors
+
+            # PDF link - look in the surrounding div
+            container = span.parent
+            if container:
+                pdf_a = container.find('a', {'title': 'Open PDF'})
+                if pdf_a:
+                    new_pub['pdf'] = pdf_a['href']
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for CoNLL %d." % (len(pubs) - old_count, year))
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_conll"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/corl_download_parse.py
+++ b/corl_download_parse.py
@@ -1,0 +1,85 @@
+"""
+Standalone helper script.
+
+Parses CoRL proceedings from proceedings.mlr.press, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_corl.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+CORL_VOLUMES = {
+    78: 2017,
+    87: 2018,
+    100: 2019,
+    155: 2020,
+    164: 2021,
+    205: 2022,
+    229: 2023,
+    270: 2024,
+    305: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(CORL_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading CoRL %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'CoRL %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for CoRL %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_corl"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/cvpr_download_parse.py
+++ b/cvpr_download_parse.py
@@ -1,0 +1,142 @@
+"""
+Standalone helper script.
+
+Parses CVPR proceedings from openaccess.thecvf.com, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_cvpr.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://openaccess.thecvf.com"
+
+
+def fetch(url):
+    """Fetch a URL and return the HTML as string, or None on error."""
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urllib.request.urlopen(req) as f:
+        return f.read()
+
+
+def get_pages_for_year(year):
+    """Return list of HTML pages to parse for a given CVPR year."""
+    # determine base URL pattern
+    if year <= 2020:
+        base = "%s/CVPR%d.py" % (BASE_URL, year)
+    else:
+        base = "%s/CVPR%d" % (BASE_URL, year)
+
+    # first try day=all
+    try:
+        html = fetch(base + "?day=all")
+        soup = BeautifulSoup(html, 'html.parser')
+        # check if it actually has papers (not a DB error)
+        if soup.find('dt', {'class': 'ptitle'}):
+            return [html]
+    except:
+        pass
+
+    # fall back to fetching the index page and finding day links
+    try:
+        html = fetch(base)
+        soup = BeautifulSoup(html, 'html.parser')
+        pages = []
+        for a in soup.find_all('a'):
+            href = a.get('href', '')
+            if 'day=' in href and 'day=all' not in href:
+                day_url = BASE_URL + '/' + href.lstrip('/')
+                try:
+                    pages.append(fetch(day_url))
+                except:
+                    pass
+        if pages:
+            return pages
+    except:
+        pass
+
+    return []
+
+
+def parse_papers(html, venue, year):
+    """Parse papers from a single HTML page. Returns list of pub dicts."""
+    soup = BeautifulSoup(html, 'html.parser')
+    results = []
+
+    for dt in soup.find_all('dt', {'class': 'ptitle'}):
+        new_pub = {}
+
+        title_tag = dt.find('a')
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        # collect authors and PDF from sibling <dd> elements
+        authors = []
+        for dd in dt.find_next_siblings('dd'):
+            if dd.find_previous_sibling('dt', {'class': 'ptitle'}) != dt:
+                break
+
+            for form in dd.find_all('form', {'class': 'authsearch'}):
+                author_input = form.find('input', {'name': 'query_author'})
+                if not author_input:
+                    author_input = form.find('input', {'name': 'query'})
+                if author_input:
+                    authors.append(author_input['value'])
+
+            for a in dd.find_all('a'):
+                href = a.get('href', '')
+                if href.endswith('.pdf') and 'supp' not in href.lower():
+                    new_pub['pdf'] = BASE_URL + '/' + href.lstrip('/')
+                    break
+
+        if authors:
+            new_pub['authors'] = authors
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        results.append(new_pub)
+
+    return results
+
+
+pubs = []
+warnings = []
+
+for year in range(2013, 2026):
+    print("downloading CVPR %d..." % (year,))
+
+    try:
+        pages = get_pages_for_year(year)
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    if not pages:
+        warnings.append("no pages found for CVPR %d" % (year,))
+        print("no data found, skipping...")
+        continue
+
+    venue = 'CVPR %d' % (year,)
+    old_count = len(pubs)
+
+    for page_html in pages:
+        pubs.extend(parse_papers(page_html, venue, year))
+
+    print("read in %d publications for CVPR %d." % (len(pubs) - old_count, year))
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_cvpr"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/cvpr_download_parse.py
+++ b/cvpr_download_parse.py
@@ -14,7 +14,11 @@ BASE_URL = "https://openaccess.thecvf.com"
 
 
 def fetch(url):
-    """Fetch a URL and return the HTML as string, or None on error."""
+    """Fetch a URL and return the response body as bytes, or None on error.
+
+    Note: returns bytes (not str). BeautifulSoup handles both bytes and str,
+    so callers can pass the result directly to BeautifulSoup.
+    """
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
     with urllib.request.urlopen(req, timeout=30) as f:
         return f.read()

--- a/cvpr_download_parse.py
+++ b/cvpr_download_parse.py
@@ -16,7 +16,7 @@ BASE_URL = "https://openaccess.thecvf.com"
 def fetch(url):
     """Fetch a URL and return the HTML as string, or None on error."""
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-    with urllib.request.urlopen(req) as f:
+    with urllib.request.urlopen(req, timeout=30) as f:
         return f.read()
 
 
@@ -35,7 +35,7 @@ def get_pages_for_year(year):
         # check if it actually has papers (not a DB error)
         if soup.find('dt', {'class': 'ptitle'}):
             return [html]
-    except:
+    except Exception:
         pass
 
     # fall back to fetching the index page and finding day links
@@ -49,11 +49,11 @@ def get_pages_for_year(year):
                 day_url = BASE_URL + '/' + href.lstrip('/')
                 try:
                     pages.append(fetch(day_url))
-                except:
+                except Exception:
                     pass
         if pages:
             return pages
-    except:
+    except Exception:
         pass
 
     return []

--- a/demo1.py
+++ b/demo1.py
@@ -6,39 +6,35 @@ from repool_util import loadPubs, openPDFs
 
 def demo1():
     """
-    You wrote an algorithm and benchmarked it on the MNIST dataset. You are 
+    You wrote an algorithm and benchmarked it on the MNIST dataset. You are
     wondering how your results compare with those in the literature:
     1. Finds all publications that mention mnist
     2. Print out their titles
     3. Open the three latest publications that mention it at least twice
-    
+
     Pre-requisites:
-    - Assumes 'pubs_nips' exists and that pdf text is present. 
-      This can be obtained by running 
-      nips_download_parse.py and then nips_add_pdftext.py, or by downloading it 
-      from site (https://sites.google.com/site/researchpooler/home)
-    
-    Side-effects:
-    - will use os call to open a pdf with default program
+    - Assumes 'pubs_nips' exists and that pdf text is present.
+      This can be obtained by running
+      nips_download_parse.py and then nips_add_pdftext.py
     """
-    
-    print "loading the NIPS publications dataset..."
+
+    print("loading the NIPS publications dataset...")
     pubs = loadPubs('pubs_nips')
-    
+
     # get all papers that mention mnist
-    p = [x for x in pubs if 'mnist' in x.get('pdf_text',{})]
-    print "titles of papers that mention MNIST dataset:"
+    p = [x for x in pubs if 'mnist' in x.get('pdf_text', {})]
+    print("titles of papers that mention MNIST dataset:")
     for x in p:
-        print x['title']
-    print "total of %d publications mention MNIST." %(len(p),)
-    
+        print(x['title'])
+    print("total of %d publications mention MNIST." % (len(p),))
+
     # sort by number of occurences
-    occ = [(x['year'], x['pdf']) for i,x in enumerate(p) if x['pdf_text']['mnist']>1]
-    occ.sort(reverse = True)
-    
+    occ = [(x['year'], x['pdf']) for i, x in enumerate(p) if x['pdf_text']['mnist'] > 1]
+    occ.sort(reverse=True)
+
     # open the top 3 latest in browser
-    print "opening the top 3..."
-    openPDFs([x for year,x in occ[:3]])
+    print("opening the top 3...")
+    openPDFs([x for year, x in occ[:3]])
 
 if __name__ == '__main__':
     demo1()

--- a/demo2.py
+++ b/demo2.py
@@ -10,27 +10,23 @@ def demo2():
     stab at some background reading, you want to:
     1. Find all NIPS publications with Deep in title
     2. open them in the browser
-    
+
     Pre-requisites:
-    - Assumes 'pubs_nips' exists. This can be obtained by running 
-      nips_download_parse.py or by downloading it from site.
-      (https://sites.google.com/site/researchpooler/home)
-    
-    Side-effects:
-    - will use os call to open a pdf with default program
+    - Assumes 'pubs_nips' exists. This can be obtained by running
+      nips_download_parse.py
     """
-    
-    print "loading the NIPS publications dataset..."
+
+    print("loading the NIPS publications dataset...")
     pubs = loadPubs('pubs_nips')
-    
+
     # get urls that correspond to publications with deep in title
     p = [x['pdf'] for x in pubs if 'deep' in x['title'].lower()]
-    
-    if len(p)>5:
-        print "oops too many (%d) results! Only opening random 5." % (len(p),)
-        p=p[:5]
-        
+
+    if len(p) > 5:
+        print("oops too many (%d) results! Only opening random 5." % (len(p),))
+        p = p[:5]
+
     openPDFs(p)
-    
+
 if __name__ == '__main__':
     demo2()

--- a/demo3.py
+++ b/demo3.py
@@ -11,46 +11,38 @@ def demo3():
     You found a cool paper online and you want to find similar papers:
     1. Download and parse the pdf
     2. Compare to text of all publications in pubs_ database
-    3. Open the top 3 matches in browser (but note that current matching alg is
-                                          very basic and could be much improved)
-    
+    3. Open the top 3 matches in browser
+
     Pre-requisites:
-    - Assumes 'pubs_nips' exists and contains pdf text inside 
-      (under key 'pdf_text'). This can be obtained by running 
-      nips_download_parse.py and then nips_add_pdftext.py 
-      or by downloading it from site.
-      (https://sites.google.com/site/researchpooler/home)
-    
-    Side-effects:
-    - will use os call to open a pdf with default program
+    - Assumes 'pubs_nips' exists and contains pdf text inside
+      (under key 'pdf_text').
     """
-    
+
     # fetch this pdf from website, parse it, and make a publication dict from it
-    # here is a random pdf from Andrew's website
     url = 'http://ai.stanford.edu/~ang/papers/icml11-DeepEnergyModels.pdf'
-    print "downloading %s..." % (url,)
-    text = convertPDF(url) #extract the text
-    bow = stringToWordDictionary(text) #extract the bag of words representation
-    p = {'pdf_text' : bow} #create a dummy publication dict
-    
+    print("downloading %s..." % (url,))
+    text = convertPDF(url)  # extract the text
+    bow = stringToWordDictionary(text)  # extract the bag of words representation
+    p = {'pdf_text': bow}  # create a dummy publication dict
+
     # calculate similarities to our publications
-    print "loading database..."
+    print("loading database...")
     pubs = loadPubs('pubs_nips')
-    print "computing similarities. (may take while with current implementation)"
+    print("computing similarities. (may take while with current implementation)")
     scores = publicationSimilarityNaive(pubs, p)
-    
+
     # find highest scoring pubs
-    lst = [(s, i) for i,s in enumerate(scores) if s>=0]
-    lst.sort(reverse = True)
-    
+    lst = [(s, i) for i, s in enumerate(scores) if s >= 0]
+    lst.sort(reverse=True)
+
     # display top 50 matches
     m = min(50, len(lst))
     for s, i in lst[:m]:
-        print "%.2f is similarity to %s." % (s, pubs[i]['title'])
-    
-    #open the top 3 in browser
-    print "opening the top 3..."
-    openPDFs([pubs[i]['pdf'] for s,i in lst[:3]])
-    
+        print("%.2f is similarity to %s." % (s, pubs[i]['title']))
+
+    # open the top 3 in browser
+    print("opening the top 3...")
+    openPDFs([pubs[i]['pdf'] for s, i in lst[:3]])
+
 if __name__ == '__main__':
     demo3()

--- a/eacl_download_parse.py
+++ b/eacl_download_parse.py
@@ -1,0 +1,89 @@
+"""
+Standalone helper script.
+
+Parses EACL (European Chapter of the Association for Computational Linguistics)
+proceedings from aclanthology.org, creates list of dictionaries that store
+information about each publication, and saves the result as a pickle called
+pubs_eacl.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://aclanthology.org"
+
+pubs = []
+warnings = []
+
+for year in range(2000, 2027):
+    url = "%s/events/eacl-%d/" % (BASE_URL, year)
+    print("downloading EACL %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'EACL %d' % (year,)
+    old_count = len(pubs)
+
+    for strong in soup.find_all('strong'):
+        a = strong.find('a', class_='align-middle')
+        if not a:
+            continue
+
+        title = a.text.strip()
+        if not title:
+            continue
+
+        # skip proceedings headers / reports
+        href = a.get('href', '')
+        if href.endswith('.0/') or 'report' in href:
+            continue
+
+        new_pub = {'title': title}
+
+        # authors are <a href="/people/..."> in the parent <span>
+        span = strong.parent
+        if span:
+            authors = []
+            for author_a in span.find_all('a'):
+                author_href = author_a.get('href', '')
+                if '/people/' in author_href:
+                    authors.append(author_a.text.strip())
+            if authors:
+                new_pub['authors'] = authors
+
+            # PDF link - look in the surrounding div
+            container = span.parent
+            if container:
+                pdf_a = container.find('a', {'title': 'Open PDF'})
+                if pdf_a:
+                    new_pub['pdf'] = pdf_a['href']
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for EACL %d." % (len(pubs) - old_count, year))
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_eacl"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/eccv_download_parse.py
+++ b/eccv_download_parse.py
@@ -1,0 +1,164 @@
+"""
+Standalone helper script.
+
+Parses ECCV proceedings from ecva.net/papers.php, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_eccv.
+
+ECCV occurs every 2 years (even years only).
+"""
+
+import urllib.request
+import re
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://www.ecva.net"
+PAPERS_URL = BASE_URL + "/papers.php"
+
+
+def fetch(url):
+    """Fetch a URL and return the HTML as bytes."""
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urllib.request.urlopen(req) as f:
+        return f.read()
+
+
+def parse_authors(raw_text):
+    """
+    Parse author string into a list of author names.
+    ECCV 2018 uses 'Last, First and Last, First' format.
+    ECCV 2020+ uses 'First Last, First Last' format.
+    """
+    raw = raw_text.strip()
+    if not raw:
+        return []
+
+    # Remove trailing/leading whitespace and asterisks (corresponding author markers)
+    raw = raw.replace('*', '').strip()
+
+    # 2018 format: "Ling, Yonggen and Bao, Linchao and Jie, Zequn"
+    # Detect by checking if the string uses " and " as separator between
+    # "Last, First" pairs
+    if ' and ' in raw and ', ' in raw:
+        parts = [p.strip() for p in raw.split(' and ')]
+        authors = []
+        for part in parts:
+            # "Last, First" -> "First Last"
+            if ', ' in part:
+                pieces = part.split(', ', 1)
+                authors.append(pieces[1].strip() + ' ' + pieces[0].strip())
+            else:
+                authors.append(part.strip())
+        return [a for a in authors if a]
+
+    # 2020+ format: "First Last, First Last, First Last"
+    authors = [a.strip() for a in raw.split(',')]
+    return [a for a in authors if a]
+
+
+def parse_papers_from_section(section_html, year):
+    """Parse papers from a single year section. Returns list of pub dicts."""
+    soup = BeautifulSoup(section_html, 'html.parser')
+    results = []
+    venue = 'ECCV %d' % (year,)
+
+    for dt in soup.find_all('dt', {'class': 'ptitle'}):
+        new_pub = {}
+
+        title_tag = dt.find('a')
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        # Collect authors and PDF from sibling <dd> elements
+        authors = []
+        for dd in dt.find_next_siblings('dd'):
+            # Stop if we hit another ptitle's dd
+            if dd.find_previous_sibling('dt', {'class': 'ptitle'}) != dt:
+                break
+
+            # First dd typically contains authors as text
+            if not authors:
+                author_text = dd.get_text(separator=' ').strip()
+                # Skip if this dd contains links (it's the PDF dd)
+                if author_text and not dd.find('a'):
+                    authors = parse_authors(author_text)
+
+            # Look for PDF link
+            for a in dd.find_all('a'):
+                href = a.get('href', '')
+                if href.endswith('.pdf') and 'supp' not in href.lower():
+                    if href.startswith('http'):
+                        new_pub['pdf'] = href
+                    else:
+                        new_pub['pdf'] = BASE_URL + '/' + href.lstrip('/')
+                    break
+
+        if authors:
+            new_pub['authors'] = authors
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        results.append(new_pub)
+
+    return results
+
+
+# Fetch the single page containing all years
+print("downloading ecva.net papers page...")
+try:
+    html = fetch(PAPERS_URL).decode('utf-8')
+except Exception as e:
+    print("error fetching papers page: %s" % (e,))
+    raise SystemExit(1)
+
+pubs = []
+warnings = []
+
+for year in range(2018, 2026, 2):  # even years only
+    print("parsing ECCV %d..." % (year,))
+
+    # Find the accordion section for this year
+    pattern = r'ECCV\s+%d\s+Papers\s*</button>\s*<div[^>]*>\s*<div[^>]*>\s*<dl>(.*?)</dl>' % (year,)
+    match = re.search(pattern, html, re.DOTALL)
+
+    if not match:
+        # Try a looser pattern
+        marker = 'ECCV %d Papers' % (year,)
+        start_idx = html.find(marker)
+        if start_idx == -1:
+            warnings.append("no section found for ECCV %d" % (year,))
+            print("no data found, skipping...")
+            continue
+
+        # Find the <dl> after this marker
+        dl_start = html.find('<dl>', start_idx)
+        dl_end = html.find('</dl>', dl_start)
+        if dl_start == -1 or dl_end == -1:
+            warnings.append("could not find <dl> block for ECCV %d" % (year,))
+            print("no data found, skipping...")
+            continue
+
+        section_html = html[dl_start:dl_end + 5]
+    else:
+        section_html = '<dl>' + match.group(1) + '</dl>'
+
+    old_count = len(pubs)
+    pubs.extend(parse_papers_from_section(section_html, year))
+    print("read in %d publications for ECCV %d." % (len(pubs) - old_count, year))
+
+# Show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_eccv"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/emnlp_download_parse.py
+++ b/emnlp_download_parse.py
@@ -1,0 +1,84 @@
+"""
+Standalone helper script.
+
+Parses EMNLP proceedings from aclanthology.org, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle called pubs_emnlp.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://aclanthology.org"
+
+pubs = []
+warnings = []
+
+for year in range(2000, 2026):
+    url = "%s/events/emnlp-%d/" % (BASE_URL, year)
+    print("downloading EMNLP %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'EMNLP %d' % (year,)
+    old_count = len(pubs)
+
+    for strong in soup.find_all('strong'):
+        a = strong.find('a', class_='align-middle')
+        if not a:
+            continue
+
+        title = a.text.strip()
+        if not title:
+            continue
+
+        href = a.get('href', '')
+        if href.endswith('.0/') or 'report' in href:
+            continue
+
+        new_pub = {'title': title}
+
+        span = strong.parent
+        if span:
+            authors = []
+            for author_a in span.find_all('a'):
+                author_href = author_a.get('href', '')
+                if '/people/' in author_href:
+                    authors.append(author_a.text.strip())
+            if authors:
+                new_pub['authors'] = authors
+
+            container = span.parent
+            if container:
+                pdf_a = container.find('a', {'title': 'Open PDF'})
+                if pdf_a:
+                    new_pub['pdf'] = pdf_a['href']
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for EMNLP %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_emnlp"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/google_search.py
+++ b/google_search.py
@@ -4,7 +4,6 @@ Functions for searching Google and retrieving urls to PDFs
 
 import urllib.request
 import urllib.parse
-import json
 
 def getPDFURL(pdf_title):
     """

--- a/google_search.py
+++ b/google_search.py
@@ -24,7 +24,7 @@ def getPDFURL(pdf_title):
 
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
     try:
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=15) as response:
             html = response.read().decode('utf-8')
     except Exception as e:
         print('Error searching Google: %s' % (e,))

--- a/google_search.py
+++ b/google_search.py
@@ -2,31 +2,39 @@
 Functions for searching Google and retrieving urls to PDFs
 """
 
-import urllib
-import simplejson
+import urllib.request
+import urllib.parse
+import json
 
 def getPDFURL(pdf_title):
     """
-    Search google for exact match of the title of this paper 
-    and return the url to the pdf file, or 'notfound' if no exact match was 
+    Search google for exact match of the title of this paper
+    and return the url to the pdf file, or 'notfound' if no exact match was
     found.
-    
+
     pdf_title: string, name of the paper.
     Returns url to the PDF, or 'notfound' if unsuccessful
+
+    Note: The original Google AJAX Search API has been retired.
+    This version uses a simple scraping approach which may be fragile.
+    For production use, consider using the Google Custom Search JSON API.
     """
-    
-    # get results in JSON
-    query = urllib.urlencode({'q' : pdf_title + ' filetype:pdf'})
-    url = 'http://ajax.googleapis.com/ajax/services/search/web?v=1.0&%s' \
-          % (query)
-    search_results = urllib.urlopen(url)
-    json = simplejson.loads(search_results.read())
-    results = json['responseData']['results']
-    
-    # sift through them in search of an exact match
-    for r in results:
-        if r['title'] == '<b>' + pdf_title + '</b>':
-            return r['url']
-    
+
+    query = urllib.parse.urlencode({'q': pdf_title + ' filetype:pdf'})
+    url = 'https://www.google.com/search?%s' % (query,)
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as response:
+            html = response.read().decode('utf-8')
+    except Exception as e:
+        print('Error searching Google: %s' % (e,))
+        return 'notfound'
+
+    # Try to extract first PDF link from results
+    import re
+    pdf_links = re.findall(r'(https?://[^\s"&]+\.pdf)', html)
+    if pdf_links:
+        return pdf_links[0]
+
     return 'notfound'
-      

--- a/iccv_download_parse.py
+++ b/iccv_download_parse.py
@@ -1,0 +1,138 @@
+"""
+Standalone helper script.
+
+Parses ICCV proceedings from openaccess.thecvf.com, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_iccv.
+
+ICCV occurs every 2 years (odd years only).
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://openaccess.thecvf.com"
+
+
+def fetch(url):
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urllib.request.urlopen(req) as f:
+        return f.read()
+
+
+def get_pages_for_year(year):
+    # 2013-2019 use .py suffix, 2021+ don't
+    if year <= 2019:
+        base = "%s/ICCV%d.py" % (BASE_URL, year)
+    else:
+        base = "%s/ICCV%d" % (BASE_URL, year)
+
+    # try day=all first
+    try:
+        html = fetch(base + "?day=all")
+        soup = BeautifulSoup(html, 'html.parser')
+        if soup.find('dt', {'class': 'ptitle'}):
+            return [html]
+    except:
+        pass
+
+    # fall back to per-day pages
+    try:
+        html = fetch(base)
+        soup = BeautifulSoup(html, 'html.parser')
+        pages = []
+        for a in soup.find_all('a'):
+            href = a.get('href', '')
+            if 'day=' in href and 'day=all' not in href:
+                day_url = BASE_URL + '/' + href.lstrip('/')
+                try:
+                    pages.append(fetch(day_url))
+                except:
+                    pass
+        if pages:
+            return pages
+    except:
+        pass
+
+    return []
+
+
+def parse_papers(html, venue, year):
+    soup = BeautifulSoup(html, 'html.parser')
+    results = []
+
+    for dt in soup.find_all('dt', {'class': 'ptitle'}):
+        new_pub = {}
+
+        title_tag = dt.find('a')
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors = []
+        for dd in dt.find_next_siblings('dd'):
+            if dd.find_previous_sibling('dt', {'class': 'ptitle'}) != dt:
+                break
+
+            for form in dd.find_all('form', {'class': 'authsearch'}):
+                author_input = form.find('input', {'name': 'query_author'})
+                if not author_input:
+                    author_input = form.find('input', {'name': 'query'})
+                if author_input:
+                    authors.append(author_input['value'])
+
+            for a in dd.find_all('a'):
+                href = a.get('href', '')
+                if href.endswith('.pdf') and 'supp' not in href.lower():
+                    new_pub['pdf'] = BASE_URL + '/' + href.lstrip('/')
+                    break
+
+        if authors:
+            new_pub['authors'] = authors
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        results.append(new_pub)
+
+    return results
+
+
+pubs = []
+warnings = []
+
+for year in range(2013, 2026, 2):  # odd years only
+    print("downloading ICCV %d..." % (year,))
+
+    try:
+        pages = get_pages_for_year(year)
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    if not pages:
+        warnings.append("no pages found for ICCV %d" % (year,))
+        print("no data found, skipping...")
+        continue
+
+    venue = 'ICCV %d' % (year,)
+    old_count = len(pubs)
+
+    for page_html in pages:
+        pubs.extend(parse_papers(page_html, venue, year))
+
+    print("read in %d publications for ICCV %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_iccv"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/iccv_download_parse.py
+++ b/iccv_download_parse.py
@@ -17,7 +17,7 @@ BASE_URL = "https://openaccess.thecvf.com"
 
 def fetch(url):
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-    with urllib.request.urlopen(req) as f:
+    with urllib.request.urlopen(req, timeout=30) as f:
         return f.read()
 
 
@@ -34,7 +34,7 @@ def get_pages_for_year(year):
         soup = BeautifulSoup(html, 'html.parser')
         if soup.find('dt', {'class': 'ptitle'}):
             return [html]
-    except:
+    except Exception:
         pass
 
     # fall back to per-day pages
@@ -48,11 +48,11 @@ def get_pages_for_year(year):
                 day_url = BASE_URL + '/' + href.lstrip('/')
                 try:
                     pages.append(fetch(day_url))
-                except:
+                except Exception:
                     pass
         if pages:
             return pages
-    except:
+    except Exception:
         pass
 
     return []

--- a/iclr_download_parse.py
+++ b/iclr_download_parse.py
@@ -30,7 +30,7 @@ PAGE_SIZE = 1000
 def fetch_json(url):
     """Fetch a URL and return parsed JSON."""
     req = urllib.request.Request(url, headers=HEADERS)
-    with urllib.request.urlopen(req) as f:
+    with urllib.request.urlopen(req, timeout=30) as f:
         return json.loads(f.read())
 
 

--- a/iclr_download_parse.py
+++ b/iclr_download_parse.py
@@ -1,0 +1,270 @@
+"""
+Standalone helper script.
+
+Parses ICLR (International Conference on Learning Representations) proceedings
+from the OpenReview API, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle in the current
+directory called pubs_iclr.
+
+Uses two OpenReview API versions:
+  - API v2 (api2.openreview.net) for 2024 onwards
+  - API v1 (api.openreview.net)  for 2018-2023
+
+For 2021-2023, accepted papers have a venue field that can be filtered on.
+For 2018-2020, accepted papers must be identified through decision/meta-review
+replies attached to each blind submission.
+"""
+
+import urllib.request
+import urllib.parse
+import json
+import time
+from repool_util import savePubs
+
+OPENREVIEW_V1 = "https://api.openreview.net"
+OPENREVIEW_V2 = "https://api2.openreview.net"
+HEADERS = {'User-Agent': 'Mozilla/5.0'}
+PAGE_SIZE = 1000
+
+
+def fetch_json(url):
+    """Fetch a URL and return parsed JSON."""
+    req = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(req) as f:
+        return json.loads(f.read())
+
+
+# --------------------------------------------------------------------------
+# API v2 fetcher (2024+)
+# --------------------------------------------------------------------------
+
+def fetch_iclr_v2(year):
+    """
+    Fetch accepted ICLR papers for a given year using the OpenReview API v2.
+    Returns a list of pub dicts.
+    """
+    pubs = []
+    offset = 0
+
+    while True:
+        url = (
+            "%s/notes?content.venueid=ICLR.cc/%d/Conference"
+            "&limit=%d&offset=%d"
+            % (OPENREVIEW_V2, year, PAGE_SIZE, offset)
+        )
+        data = fetch_json(url)
+        notes = data.get('notes', [])
+        if not notes:
+            break
+
+        for note in notes:
+            c = note.get('content', {})
+            title_val = c.get('title', {}).get('value', '')
+            authors_val = c.get('authors', {}).get('value', [])
+            pdf_val = c.get('pdf', {}).get('value', '')
+
+            if not title_val:
+                continue
+
+            new_pub = {
+                'title': title_val,
+                'authors': list(authors_val),
+                'venue': 'ICLR %d' % year,
+                'year': year,
+            }
+            if pdf_val:
+                if pdf_val.startswith('/'):
+                    pdf_val = 'https://openreview.net' + pdf_val
+                new_pub['pdf'] = pdf_val
+
+            pubs.append(new_pub)
+
+        offset += len(notes)
+        time.sleep(0.2)
+
+    return pubs
+
+
+# --------------------------------------------------------------------------
+# API v1 fetcher with venue filter (2021-2023)
+# --------------------------------------------------------------------------
+
+# Accepted venue strings by year. Case and wording vary across years.
+VENUE_FILTERS = {
+    2021: ['ICLR 2021 Poster', 'ICLR 2021 Oral', 'ICLR 2021 Spotlight'],
+    2022: ['ICLR 2022 Poster', 'ICLR 2022 Oral', 'ICLR 2022 Spotlight'],
+    2023: ['ICLR 2023 poster', 'ICLR 2023 oral',
+           'ICLR 2023 notable top 5%', 'ICLR 2023 notable top 25%'],
+}
+
+
+def fetch_iclr_v1_venue(year):
+    """
+    Fetch accepted ICLR papers for years where API v1 blind submissions
+    contain a venue field (2021-2023). Returns a list of pub dicts.
+    """
+    pubs = []
+    venue_strings = VENUE_FILTERS.get(year, [])
+    invitation = "ICLR.cc/%d/Conference/-/Blind_Submission" % year
+
+    for venue_str in venue_strings:
+        offset = 0
+        while True:
+            encoded_venue = urllib.parse.quote(venue_str)
+            url = (
+                "%s/notes?invitation=%s"
+                "&content.venue=%s"
+                "&limit=%d&offset=%d"
+                % (OPENREVIEW_V1, invitation, encoded_venue, PAGE_SIZE, offset)
+            )
+            data = fetch_json(url)
+            notes = data.get('notes', [])
+            if not notes:
+                break
+
+            for note in notes:
+                c = note.get('content', {})
+                title = c.get('title', '')
+                authors = c.get('authors', [])
+                pdf = c.get('pdf', '')
+
+                if not title:
+                    continue
+
+                new_pub = {
+                    'title': title,
+                    'authors': list(authors),
+                    'venue': 'ICLR %d' % year,
+                    'year': year,
+                }
+                if pdf:
+                    if pdf.startswith('/'):
+                        pdf = 'https://openreview.net' + pdf
+                    new_pub['pdf'] = pdf
+
+                pubs.append(new_pub)
+
+            offset += len(notes)
+            time.sleep(0.2)
+
+    return pubs
+
+
+# --------------------------------------------------------------------------
+# API v1 fetcher with decision lookup (2018-2020)
+# --------------------------------------------------------------------------
+
+def fetch_iclr_v1_decisions(year):
+    """
+    Fetch accepted ICLR papers for years where blind submissions lack a
+    venue field (2018-2020). We fetch all submissions with their direct
+    replies and check the decision/meta-review for acceptance.
+
+    For 2018, the acceptance decision is stored in a reply with a 'decision'
+    content field. For 2019, it is in a 'recommendation' field from the
+    meta-review. For 2020, it is in a 'decision' field in a Decision reply.
+
+    Returns a list of pub dicts.
+    """
+    pubs = []
+    invitation = "ICLR.cc/%d/Conference/-/Blind_Submission" % year
+    offset = 0
+    total_checked = 0
+
+    while True:
+        url = (
+            "%s/notes?invitation=%s"
+            "&details=directReplies"
+            "&limit=%d&offset=%d"
+            % (OPENREVIEW_V1, invitation, PAGE_SIZE, offset)
+        )
+        data = fetch_json(url)
+        notes = data.get('notes', [])
+        if not notes:
+            break
+
+        for note in notes:
+            total_checked += 1
+            accepted = False
+            replies = note.get('details', {}).get('directReplies', [])
+            for reply in replies:
+                rc = reply.get('content', {})
+                decision = rc.get('decision', '') or rc.get('recommendation', '')
+                if 'Accept' in decision and 'Workshop' not in decision:
+                    accepted = True
+                    break
+
+            if not accepted:
+                continue
+
+            c = note.get('content', {})
+            title = c.get('title', '')
+            authors = c.get('authors', [])
+            pdf = c.get('pdf', '')
+
+            if not title:
+                continue
+
+            new_pub = {
+                'title': title,
+                'authors': list(authors),
+                'venue': 'ICLR %d' % year,
+                'year': year,
+            }
+            if pdf:
+                if pdf.startswith('/'):
+                    pdf = 'https://openreview.net' + pdf
+                new_pub['pdf'] = pdf
+
+            pubs.append(new_pub)
+
+        offset += len(notes)
+        time.sleep(0.3)
+
+    return pubs
+
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+
+pubs = []
+warnings = []
+
+for year in range(2018, 2026):
+    print("downloading proceedings from ICLR %d..." % year)
+
+    try:
+        if year >= 2024:
+            year_pubs = fetch_iclr_v2(year)
+        elif year >= 2021:
+            year_pubs = fetch_iclr_v1_venue(year)
+        else:
+            year_pubs = fetch_iclr_v1_decisions(year)
+    except Exception as e:
+        warnings.append("error fetching ICLR %d: %s" % (year, e))
+        print("  error: %s, skipping..." % e)
+        continue
+
+    if not year_pubs:
+        warnings.append("no papers found for ICLR %d" % year)
+        print("  no papers found, skipping...")
+    else:
+        print("  read in %d publications for ICLR %d." % (len(year_pubs), year))
+
+    pubs.extend(year_pubs)
+
+# show warnings, if any were generated
+if len(warnings) > 0:
+    print("%d warnings:" % len(warnings))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+# finally, save pickle as output
+print("read in a total of %d publications." % len(pubs))
+fname = "pubs_iclr"
+print("saving pickle in %s" % fname)
+savePubs(fname, pubs)
+print("all done.")

--- a/icml_download_parse.py
+++ b/icml_download_parse.py
@@ -1,0 +1,96 @@
+"""
+Standalone helper script.
+
+Parses ICML proceedings from proceedings.mlr.press, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_icml.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+# ICML volume numbers mapped to years
+ICML_VOLUMES = {
+    28: 2013,
+    32: 2014,
+    37: 2015,
+    48: 2016,
+    70: 2017,
+    80: 2018,
+    97: 2019,
+    119: 2020,
+    139: 2021,
+    162: 2022,
+    202: 2023,
+    235: 2024,
+    267: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(ICML_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading ICML %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'ICML %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            # authors separated by &nbsp; in HTML, but .text gives us the text
+            authors_text = authors_tag.get_text()
+            authors = [a.strip() for a in authors_text.split(',')]
+            # clean up trailing semicolons
+            authors = [a.rstrip(';').strip() for a in authors if a.strip()]
+            new_pub['authors'] = authors
+
+        # find PDF link
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for ICML %d." % (len(pubs) - old_count, year))
+
+# show warnings, if any were generated
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+# finally, save pickle as output
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_icml"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/ijcai_download_parse.py
+++ b/ijcai_download_parse.py
@@ -1,0 +1,202 @@
+"""
+Standalone helper script.
+
+Parses IJCAI proceedings from ijcai.org, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle called pubs_ijcai.
+
+Two HTML formats are handled:
+  - 2017+: structured divs with class="paper_wrapper"
+  - 2013-2016: flat <p> tags with titles in <a> and authors in <i> or <em>
+
+IJCAI was biennial before 2016 (odd years only: 2013, 2015), then
+annual from 2016 onward.  Years that return 404 are silently skipped.
+"""
+
+import urllib.request
+import re
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://www.ijcai.org"
+
+YEARS = list(range(2013, 2026))
+
+
+def fetch(url):
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urllib.request.urlopen(req) as f:
+        return f.read().decode('utf-8')
+
+
+def parse_new_format(soup, year):
+    """Parse proceedings pages from 2017 onward (div.paper_wrapper)."""
+    papers = []
+    for pw in soup.find_all('div', class_='paper_wrapper'):
+        new_pub = {}
+
+        title_div = pw.find('div', class_='title')
+        if not title_div:
+            continue
+        new_pub['title'] = title_div.get_text(strip=True)
+
+        authors_div = pw.find('div', class_='authors')
+        if authors_div:
+            authors_text = authors_div.get_text(strip=True)
+            new_pub['authors'] = [a.strip() for a in authors_text.split(',')
+                                  if a.strip()]
+
+        details_div = pw.find('div', class_='details')
+        if details_div:
+            for a in details_div.find_all('a'):
+                href = a.get('href', '')
+                if href.endswith('.pdf'):
+                    # Relative link like "0001.pdf"
+                    new_pub['pdf'] = "%s/proceedings/%d/%s" % (
+                        BASE_URL, year, href)
+                    break
+
+        new_pub['venue'] = 'IJCAI %d' % year
+        new_pub['year'] = year
+        papers.append(new_pub)
+    return papers
+
+
+def parse_old_format(soup, year):
+    """Parse proceedings pages from 2013-2016 (flat <p> tags)."""
+    papers = []
+    # The short year code used in URLs (e.g. 13 for 2013)
+    short_year = str(year % 100).zfill(2)
+
+    for p_tag in soup.find_all('p'):
+        # A paper <p> must contain a PDF link and an author tag
+        pdf_link = None
+        for a in p_tag.find_all('a'):
+            href = a.get('href', '')
+            if '.pdf' in href and 'Papers/' in href:
+                pdf_link = href
+                break
+
+        if not pdf_link:
+            continue
+
+        # Authors are in <i> (2013, 2016) or <em> (2015)
+        authors_tag = p_tag.find('i')
+        if not authors_tag:
+            authors_tag = p_tag.find('em')
+        if not authors_tag:
+            continue
+
+        # Extract title.  Two layouts exist:
+        #   2013: <a href="...pdf">Title</a> / page_num
+        #   2015-2016: Title / page_num  (plain text, PDF <a> has no text
+        #              or is at the end of the <p>)
+        title_a = None
+        for a in p_tag.find_all('a'):
+            href = a.get('href', '')
+            if '.pdf' in href and 'Papers/' in href:
+                link_text = a.get_text(strip=True)
+                # In 2013 the link text IS the title; in 2015/2016 it is
+                # just the word "PDF"
+                if link_text and link_text.lower() != 'pdf':
+                    title_a = a
+                break
+
+        if title_a:
+            title = title_a.get_text(strip=True)
+        else:
+            # Title is the plain text before the first <br> or " / "
+            # Get the first text node of the <p>
+            first_text = ''
+            for child in p_tag.children:
+                if isinstance(child, str):
+                    first_text = child.strip()
+                    if first_text:
+                        break
+                elif child.name == 'br':
+                    break
+                elif child.name == 'a':
+                    # Could be the title link (2013 style)
+                    first_text = child.get_text(strip=True)
+                    break
+            title = first_text
+
+        if not title:
+            continue
+
+        # Skip front matter entries (preface, organization, committee, etc.)
+        skip_keywords = ['Preface', 'Conference Organization',
+                         'IJCAI Organization', 'Past IJCAI Conferences',
+                         'Program Committee', 'Organizers and Sponsors',
+                         'Awards and Distinguished', 'Contents',
+                         'Author Index', 'Keyword Index',
+                         'Conference Sponsors', 'Conference Organizers']
+        if any(kw.lower() in title.lower() for kw in skip_keywords):
+            continue
+
+        # Remove trailing page number like " / 20" or " / xxxiii"
+        title = re.sub(r'\s*/\s*[\dxlvicXLVIC]+\s*$', '', title).strip()
+
+        new_pub = {}
+        new_pub['title'] = title
+
+        authors_text = authors_tag.get_text(strip=True)
+        new_pub['authors'] = [a.strip() for a in authors_text.split(',')
+                              if a.strip()]
+
+        # Normalize the PDF link to a full URL
+        if pdf_link.startswith('http'):
+            new_pub['pdf'] = pdf_link
+        else:
+            new_pub['pdf'] = BASE_URL + pdf_link
+
+        new_pub['venue'] = 'IJCAI %d' % year
+        new_pub['year'] = year
+        papers.append(new_pub)
+    return papers
+
+
+pubs = []
+warnings = []
+
+for year in YEARS:
+    url = "%s/proceedings/%d" % (BASE_URL, year)
+    print("downloading IJCAI %d..." % year)
+
+    try:
+        html = fetch(url)
+    except Exception as e:
+        if '404' in str(e) or 'Not Found' in str(e):
+            print("  no proceedings found for %d, skipping." % year)
+        else:
+            warnings.append("error fetching %d: %s" % (year, e))
+            print("  error: %s" % e)
+        continue
+
+    print("  done. Parsing...")
+    soup = BeautifulSoup(html, 'html.parser')
+
+    old_count = len(pubs)
+
+    # Detect format: new (2017+) uses div.paper_wrapper
+    if soup.find('div', class_='paper_wrapper'):
+        papers = parse_new_format(soup, year)
+    else:
+        papers = parse_old_format(soup, year)
+
+    pubs.extend(papers)
+    print("  read in %d publications for IJCAI %d." % (
+        len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % len(warnings))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % len(pubs))
+fname = "pubs_ijcai"
+print("saving pickle in %s" % fname)
+savePubs(fname, pubs)
+print("all done.")

--- a/ijcnlp_download_parse.py
+++ b/ijcnlp_download_parse.py
@@ -1,0 +1,89 @@
+"""
+Standalone helper script.
+
+Parses IJCNLP (International Joint Conference on Natural Language Processing)
+proceedings from aclanthology.org, creates list of dictionaries that store
+information about each publication, and saves the result as a pickle called
+pubs_ijcnlp.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://aclanthology.org"
+
+pubs = []
+warnings = []
+
+for year in range(2005, 2027):
+    url = "%s/events/ijcnlp-%d/" % (BASE_URL, year)
+    print("downloading IJCNLP %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'IJCNLP %d' % (year,)
+    old_count = len(pubs)
+
+    for strong in soup.find_all('strong'):
+        a = strong.find('a', class_='align-middle')
+        if not a:
+            continue
+
+        title = a.text.strip()
+        if not title:
+            continue
+
+        # skip proceedings headers / reports
+        href = a.get('href', '')
+        if href.endswith('.0/') or 'report' in href:
+            continue
+
+        new_pub = {'title': title}
+
+        # authors are <a href="/people/..."> in the parent <span>
+        span = strong.parent
+        if span:
+            authors = []
+            for author_a in span.find_all('a'):
+                author_href = author_a.get('href', '')
+                if '/people/' in author_href:
+                    authors.append(author_a.text.strip())
+            if authors:
+                new_pub['authors'] = authors
+
+            # PDF link - look in the surrounding div
+            container = span.parent
+            if container:
+                pdf_a = container.find('a', {'title': 'Open PDF'})
+                if pdf_a:
+                    new_pub['pdf'] = pdf_a['href']
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for IJCNLP %d." % (len(pubs) - old_count, year))
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_ijcnlp"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/interspeech_download_parse.py
+++ b/interspeech_download_parse.py
@@ -1,0 +1,100 @@
+"""
+Standalone helper script.
+
+Parses INTERSPEECH proceedings from isca-archive.org, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle called pubs_interspeech.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://www.isca-archive.org"
+
+pubs = []
+warnings = []
+
+for year in range(2016, 2025):
+    url = "%s/interspeech_%d/" % (BASE_URL, year)
+    print("downloading INTERSPEECH %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'INTERSPEECH %d' % (year,)
+    old_count = len(pubs)
+
+    # Each paper is an <a class="w3-text" href="slug_interspeech.html">
+    # containing a <p> with the title text, a <br>, and a
+    # <span class="w3-text w3-text-theme"> with the authors.
+    for a_tag in soup.find_all('a', class_='w3-text'):
+        href = a_tag.get('href', '')
+        if '_interspeech.html' not in href:
+            continue
+
+        p_tag = a_tag.find('p')
+        if not p_tag:
+            continue
+
+        # Extract authors from the span
+        author_span = p_tag.find('span', class_='w3-text-theme')
+        authors_text = ''
+        if author_span:
+            authors_text = author_span.get_text(strip=True)
+
+        # Extract title: get all text from <p>, then remove authors portion
+        # The <p> contains: Title <br> <span>Authors</span>
+        # We can get the title by removing the span and getting remaining text
+        span_clone = author_span.extract() if author_span else None
+        title = p_tag.get_text(strip=True)
+
+        if not title:
+            if span_clone:
+                p_tag.append(span_clone)
+            continue
+
+        new_pub = {'title': title}
+
+        # Parse authors (comma-separated in the span)
+        if authors_text:
+            authors = [a.strip() for a in authors_text.split(',')]
+            authors = [a for a in authors if a]
+            new_pub['authors'] = authors
+
+        # PDF URL: replace .html with .pdf in the href
+        pdf_url = "%s/interspeech_%d/%s" % (BASE_URL, year, href.replace('.html', '.pdf'))
+        new_pub['pdf'] = pdf_url
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+        # Restore the span so we don't break parsing of subsequent elements
+        if span_clone:
+            p_tag.append(span_clone)
+
+    print("read in %d publications for INTERSPEECH %d." % (len(pubs) - old_count, year))
+
+# show warnings, if any were generated
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+# finally, save pickle as output
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_interspeech"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/jmlr_download_parse.py
+++ b/jmlr_download_parse.py
@@ -1,0 +1,113 @@
+"""
+Standalone helper script.
+
+Parses JMLR (Journal of Machine Learning Research) papers from
+jmlr.org, creates list of dictionaries that store information about
+each publication, and saves the result as a pickle called pubs_jmlr.
+"""
+
+import re
+import urllib.request
+from bs4 import BeautifulSoup, NavigableString
+from repool_util import savePubs
+
+BASE_URL = "https://jmlr.org"
+
+# Volumes 1-26 cover years 2000-2025.
+# The year is extracted from each paper's metadata rather than hardcoded,
+# since the volume-to-year mapping is not perfectly regular (e.g. volumes
+# 4 and 5 both correspond to 2003).
+VOLUMES = list(range(1, 27))
+
+pubs = []
+warnings = []
+
+for vol in VOLUMES:
+    url = "%s/papers/v%d/" % (BASE_URL, vol)
+    print("downloading JMLR volume %d..." % vol)
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching volume %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+
+    for dl in soup.find_all('dl'):
+        dt = dl.find('dt')
+        dd = dl.find('dd')
+        if not dt or not dd:
+            continue
+
+        # In older volumes, <dt> is not properly closed before <dd>,
+        # so BeautifulSoup nests <dd> inside <dt>.  Extract only the
+        # direct NavigableString children of <dt> to get the title.
+        title = ''.join(
+            s for s in dt.children if isinstance(s, NavigableString)
+        ).strip()
+        if not title:
+            continue
+
+        new_pub = {}
+        new_pub['title'] = title
+
+        # Parse authors from the bold/italic text inside dd.
+        # The dd typically starts with <b><i>Author1, Author2</i></b>; ...
+        dd_text = dd.get_text()
+
+        # Authors appear before the semicolon
+        author_part = dd_text.split(';')[0].strip() if ';' in dd_text else ''
+        if author_part:
+            authors = [a.strip() for a in author_part.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        # Extract year from the metadata text after the semicolon.
+        # The year appears at the end: ", 2024." -- match that to avoid
+        # false positives from issue numbers like (2026) or paper IDs.
+        year_match = re.search(r',\s*(20\d{2})\s*\.', dd_text)
+        if year_match:
+            new_pub['year'] = int(year_match.group(1))
+        else:
+            new_pub['year'] = 1999 + vol  # fallback estimate
+
+        # Find PDF link
+        for a in dd.find_all('a'):
+            link_text = a.get_text(strip=True).lower()
+            href = a.get('href', '')
+            if 'pdf' in link_text or 'pdf' in href.lower():
+                # Normalize the URL
+                if href.startswith('http'):
+                    new_pub['pdf'] = href
+                elif href.startswith('/'):
+                    new_pub['pdf'] = BASE_URL + href
+                else:
+                    new_pub['pdf'] = BASE_URL + '/papers/v%d/' % vol + href
+                break
+
+        new_pub['venue'] = 'JMLR %d' % new_pub['year']
+        pubs.append(new_pub)
+
+    added = len(pubs) - old_count
+    print("read in %d publications for JMLR volume %d." % (added, vol))
+
+    if added == 0:
+        warnings.append("No papers found for volume %d" % vol)
+
+if len(warnings) > 0:
+    print("%d warnings:" % len(warnings))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % len(pubs))
+fname = "pubs_jmlr"
+print("saving pickle in %s" % fname)
+savePubs(fname, pubs)
+print("all done.")

--- a/l4dc_download_parse.py
+++ b/l4dc_download_parse.py
@@ -1,0 +1,83 @@
+"""
+Standalone helper script.
+
+Parses L4DC (Learning for Dynamics and Control) proceedings from
+proceedings.mlr.press, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle in current directory
+called pubs_l4dc.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+L4DC_VOLUMES = {
+    120: 2020,
+    144: 2021,
+    168: 2022,
+    211: 2023,
+    242: 2024,
+    283: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(L4DC_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading L4DC %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'L4DC %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for L4DC %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_l4dc"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/miccai_download_parse.py
+++ b/miccai_download_parse.py
@@ -1,0 +1,116 @@
+"""
+Standalone helper script.
+
+Parses MICCAI (Medical Image Computing and Computer Assisted Intervention)
+proceedings from papers.miccai.org, creates list of dictionaries that store
+information about each publication, and saves the result as a pickle in the
+current directory called pubs_miccai.
+
+As of writing, only MICCAI 2024 and 2025 are available on the site.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://papers.miccai.org"
+
+
+def fetch(url):
+    """Fetch a URL and return the HTML as bytes."""
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urllib.request.urlopen(req) as f:
+        return f.read()
+
+
+def parse_papers(html, year):
+    """
+    Parse papers from a MICCAI year page.
+
+    Each paper entry is a <div class="posts-list-item"> containing:
+      - A <b> tag with the paper title
+      - Author <a> tags linking to /miccai-YYYY/tags#AuthorName
+      - A PDF <a> tag linking to the paper PDF
+    """
+    soup = BeautifulSoup(html, 'html.parser')
+    results = []
+    venue = 'MICCAI %d' % (year,)
+
+    for div in soup.find_all('div', {'class': 'posts-list-item'}):
+        new_pub = {}
+
+        # Title is in the <b> tag
+        title_tag = div.find('b')
+        if not title_tag:
+            continue
+        new_pub['title'] = title_tag.get_text().strip()
+
+        # Authors are <a> tags whose href contains /tags#
+        authors = []
+        for a in div.find_all('a'):
+            href = a.get('href', '')
+            if '/tags#' in href:
+                # The link text is "Last, First" -- convert to "First Last"
+                raw = a.get_text().strip()
+                if ', ' in raw:
+                    parts = raw.split(', ', 1)
+                    authors.append(parts[1].strip() + ' ' + parts[0].strip())
+                else:
+                    authors.append(raw)
+
+        if authors:
+            new_pub['authors'] = authors
+
+        # PDF link
+        for a in div.find_all('a'):
+            href = a.get('href', '')
+            if href.endswith('.pdf'):
+                if href.startswith('http'):
+                    new_pub['pdf'] = href
+                else:
+                    new_pub['pdf'] = BASE_URL + '/' + href.lstrip('/')
+                break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        results.append(new_pub)
+
+    return results
+
+
+pubs = []
+warnings = []
+
+for year in range(2024, 2027):
+    url = "%s/miccai-%d/" % (BASE_URL, year)
+    print("downloading MICCAI %d from %s ..." % (year, url))
+
+    try:
+        html = fetch(url).decode('utf-8')
+    except Exception as e:
+        warnings.append("could not fetch MICCAI %d: %s" % (year, e))
+        print("error fetching, skipping...")
+        continue
+
+    # Check if the page actually has paper entries
+    if 'posts-list-item' not in html:
+        warnings.append("no papers found on page for MICCAI %d" % (year,))
+        print("no papers found, skipping...")
+        continue
+
+    old_count = len(pubs)
+    pubs.extend(parse_papers(html, year))
+    print("read in %d publications for MICCAI %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_miccai"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/midl_download_parse.py
+++ b/midl_download_parse.py
@@ -1,0 +1,83 @@
+"""
+Standalone helper script.
+
+Parses MIDL (Medical Imaging with Deep Learning) proceedings from
+proceedings.mlr.press, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle in current directory
+called pubs_midl.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+MIDL_VOLUMES = {
+    102: 2019,
+    121: 2020,
+    143: 2021,
+    172: 2022,
+    227: 2023,
+    250: 2024,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(MIDL_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading MIDL %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'MIDL %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for MIDL %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_midl"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/mlhc_download_parse.py
+++ b/mlhc_download_parse.py
@@ -1,0 +1,86 @@
+"""
+Standalone helper script.
+
+Parses MLHC (Machine Learning for Healthcare) proceedings from
+proceedings.mlr.press, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle in current directory
+called pubs_mlhc.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+MLHC_VOLUMES = {
+    56: 2016,
+    85: 2018,
+    106: 2019,
+    126: 2020,
+    149: 2021,
+    182: 2022,
+    219: 2023,
+    252: 2024,
+    298: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(MLHC_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading MLHC %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'MLHC %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for MLHC %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_mlhc"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/naacl_download_parse.py
+++ b/naacl_download_parse.py
@@ -1,0 +1,88 @@
+"""
+Standalone helper script.
+
+Parses NAACL proceedings from aclanthology.org, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle called pubs_naacl.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://aclanthology.org"
+
+pubs = []
+warnings = []
+
+for year in range(2000, 2026):
+    url = "%s/events/naacl-%d/" % (BASE_URL, year)
+    print("downloading NAACL %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("  skipping (no proceedings): %s" % str(e)[:60])
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'NAACL %d' % (year,)
+    old_count = len(pubs)
+
+    for strong in soup.find_all('strong'):
+        a = strong.find('a', class_='align-middle')
+        if not a:
+            continue
+
+        title = a.text.strip()
+        if not title:
+            continue
+
+        href = a.get('href', '')
+        if href.endswith('.0/') or 'report' in href:
+            continue
+
+        new_pub = {'title': title}
+
+        span = strong.parent
+        if span:
+            authors = []
+            for author_a in span.find_all('a'):
+                author_href = author_a.get('href', '')
+                if '/people/' in author_href:
+                    authors.append(author_a.text.strip())
+            if authors:
+                new_pub['authors'] = authors
+
+            container = span.parent
+            if container:
+                pdf_a = container.find('a', {'title': 'Open PDF'})
+                if pdf_a:
+                    new_pub['pdf'] = pdf_a['href']
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    count = len(pubs) - old_count
+    if count > 0:
+        print("read in %d publications for NAACL %d." % (count, year))
+    else:
+        print("  no papers found.")
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_naacl"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/nips_add_pdftext.py
+++ b/nips_add_pdftext.py
@@ -20,27 +20,18 @@ for i, p in enumerate(pubs):
     # search to try to look up a link for the pdf first.
     if 'pdf' in p and 'pdf_text' not in p:
 
-        # try to open the PDF from downloaded location
+        # convert abstract page URL to direct PDF URL
+        pdf_url = p['pdf'].replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
+
         processed = False
         try:
-            floc = p['pdf'].index('NIPS')
-            fname = p['pdf'][floc:]
-            txt = convertPDF('downloads/'+fname)
+            print('downloading pdf for [%s] and parsing...' % (p.get('title', 'an un-titled paper')))
+            txt = convertPDF(pdf_url)
             processed = True
-            print('found %s in file!' % (p['title'],))
+            print('processed!')
         except:
-            pass
-
-        if not processed:
-            # download the PDF and convert to text
-            try:
-                print('downloading pdf for [%s] and parsing...' % (p.get('title', 'an un-titled paper')))
-                txt = convertPDF(p['pdf'])
-                processed = True
-                print('processed from url!')
-            except:
-                print('error: unable to open download the pdf from %s' % (p['pdf'],))
-                print('skipping...')
+            print('error: unable to download the pdf from %s' % (pdf_url,))
+            print('skipping...')
 
         if processed:
             # convert to bag of words and store

--- a/nips_add_pdftext.py
+++ b/nips_add_pdftext.py
@@ -20,11 +20,16 @@ for i, p in enumerate(pubs):
     # search to try to look up a link for the pdf first.
     if 'pdf' in p and 'pdf_text' not in p:
 
-        # convert abstract page URL to direct PDF URL
-        if '-Abstract-Conference.html' in p['pdf']:
-            pdf_url = p['pdf'].replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
-        else:
-            pdf_url = p['pdf']
+        # convert abstract page URL to direct PDF URL (handles multiple formats)
+        pdf_url = p['pdf']
+        for abstract_suffix, paper_suffix in [
+            ('-Abstract-Conference.html', '-Paper-Conference.pdf'),
+            ('-Abstract-Datasets_and_Benchmarks.html', '-Paper-Datasets_and_Benchmarks.pdf'),
+            ('-Abstract.html', '-Paper.pdf'),
+        ]:
+            if abstract_suffix in pdf_url:
+                pdf_url = pdf_url.replace(abstract_suffix, paper_suffix).replace('/hash/', '/file/')
+                break
 
         processed = False
         try:

--- a/nips_add_pdftext.py
+++ b/nips_add_pdftext.py
@@ -1,7 +1,7 @@
 """
 Standalone helper script.
 
-Load nips pubs_ file, and adds to every paper its word counts under key 
+Load nips pubs_ file, and adds to every paper its word counts under key
 'pdf_text'. The PDF for each paper is downloaded from NIPS site.
 """
 
@@ -9,17 +9,17 @@ from repool_util import loadPubs, savePubs, stringToWordDictionary
 from pdf_read import convertPDF
 
 pubs_all = loadPubs('pubs_nips')
-print 'loaded pubs with %d entries.' % (len(pubs_all),)
+print('loaded pubs with %d entries.' % (len(pubs_all),))
 
-#possibly place restrictions on pubs to process here
+# possibly place restrictions on pubs to process here
 pubs = pubs_all
 
-for i,p in enumerate(pubs):
-    
-    #if the pdf url does not exist, in future this could possibly use google
-    #search to try to look up a link for the pdf first.
-    if p.has_key('pdf') and not p.has_key('pdf_text'):
-        
+for i, p in enumerate(pubs):
+
+    # if the pdf url does not exist, in future this could possibly use google
+    # search to try to look up a link for the pdf first.
+    if 'pdf' in p and 'pdf_text' not in p:
+
         # try to open the PDF from downloaded location
         processed = False
         try:
@@ -27,29 +27,28 @@ for i,p in enumerate(pubs):
             fname = p['pdf'][floc:]
             txt = convertPDF('downloads/'+fname)
             processed = True
-            print 'found %s in file!' % (p['title'],)
+            print('found %s in file!' % (p['title'],))
         except:
             pass
-            
+
         if not processed:
             # download the PDF and convert to text
             try:
-                print 'downloading pdf for [%s] and parsing...' % (p.get('title', 'an un-titled paper'))
+                print('downloading pdf for [%s] and parsing...' % (p.get('title', 'an un-titled paper')))
                 txt = convertPDF(p['pdf'])
                 processed = True
-                print 'processed from url!'
+                print('processed from url!')
             except:
-                print 'error: unable to open download the pdf from %s' % (p['pdf'],)
-                print 'skipping...'
-        
+                print('error: unable to open download the pdf from %s' % (p['pdf'],))
+                print('skipping...')
+
         if processed:
             # convert to bag of words and store
             try:
                 p['pdf_text'] = stringToWordDictionary(txt)
             except:
-                print 'was unable to convert text to bag of words. Skipped.'
-                
-        
-    print '%d/%d = %.2f%% done.' % (i+1, len(pubs), 100*(i+1.0)/len(pubs))
-    
+                print('was unable to convert text to bag of words. Skipped.')
+
+    print('%d/%d = %.2f%% done.' % (i+1, len(pubs), 100*(i+1.0)/len(pubs)))
+
 savePubs('pubs_nips', pubs_all)

--- a/nips_add_pdftext.py
+++ b/nips_add_pdftext.py
@@ -21,7 +21,10 @@ for i, p in enumerate(pubs):
     if 'pdf' in p and 'pdf_text' not in p:
 
         # convert abstract page URL to direct PDF URL
-        pdf_url = p['pdf'].replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
+        if '-Abstract-Conference.html' in p['pdf']:
+            pdf_url = p['pdf'].replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
+        else:
+            pdf_url = p['pdf']
 
         processed = False
         try:

--- a/nips_add_pdftext.py
+++ b/nips_add_pdftext.py
@@ -37,16 +37,16 @@ for i, p in enumerate(pubs):
             txt = convertPDF(pdf_url)
             processed = True
             print('processed!')
-        except:
-            print('error: unable to download the pdf from %s' % (pdf_url,))
+        except Exception as e:
+            print('error: unable to download the pdf from %s: %s' % (pdf_url, e))
             print('skipping...')
 
         if processed:
             # convert to bag of words and store
             try:
                 p['pdf_text'] = stringToWordDictionary(txt)
-            except:
-                print('was unable to convert text to bag of words. Skipped.')
+            except Exception as e:
+                print('was unable to convert text to bag of words: %s. Skipped.' % (e,))
 
     print('%d/%d = %.2f%% done.' % (i+1, len(pubs), 100*(i+1.0)/len(pubs)))
 

--- a/nips_download_parse.py
+++ b/nips_download_parse.py
@@ -7,13 +7,14 @@ pickle in current directory called pubs_nips.
 """
 
 import urllib.request
+from datetime import datetime
 from bs4 import BeautifulSoup
 from repool_util import savePubs
 
 pubs = []
 warnings = []
 
-for year in range(2006, 2024):
+for year in range(2006, datetime.now().year + 1):
     url = "https://proceedings.neurips.cc/paper_files/paper/%d" % (year,)
     print("downloading proceedings from NeurIPS year %d..." % (year,))
 

--- a/nips_download_parse.py
+++ b/nips_download_parse.py
@@ -45,7 +45,9 @@ for year in range(2006, datetime.now().year + 1):
             continue
 
         new_pub['title'] = title_tag.text.strip()
-        new_pub['pdf'] = 'https://proceedings.neurips.cc' + title_tag['href']
+        page_url = 'https://proceedings.neurips.cc' + title_tag['href']
+        new_pub['url'] = page_url
+        new_pub['pdf'] = page_url.replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
 
         authors_tag = entry.find('span', {'class': 'paper-authors'})
         if authors_tag:

--- a/nips_download_parse.py
+++ b/nips_download_parse.py
@@ -20,7 +20,7 @@ for year in range(2006, datetime.now().year + 1):
 
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
     try:
-        with urllib.request.urlopen(req) as f:
+        with urllib.request.urlopen(req, timeout=30) as f:
             s = f.read()
     except Exception as e:
         print("error fetching year %d: %s, skipping..." % (year, e))

--- a/nips_download_parse.py
+++ b/nips_download_parse.py
@@ -47,7 +47,17 @@ for year in range(2006, datetime.now().year + 1):
         new_pub['title'] = title_tag.text.strip()
         page_url = 'https://proceedings.neurips.cc' + title_tag['href']
         new_pub['url'] = page_url
-        new_pub['pdf'] = page_url.replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
+        # Convert abstract page URL to direct PDF URL (handles multiple formats)
+        pdf_url = page_url
+        for abstract_suffix, paper_suffix in [
+            ('-Abstract-Conference.html', '-Paper-Conference.pdf'),
+            ('-Abstract-Datasets_and_Benchmarks.html', '-Paper-Datasets_and_Benchmarks.pdf'),
+            ('-Abstract.html', '-Paper.pdf'),
+        ]:
+            if abstract_suffix in pdf_url:
+                pdf_url = pdf_url.replace(abstract_suffix, paper_suffix).replace('/hash/', '/file/')
+                break
+        new_pub['pdf'] = pdf_url
 
         authors_tag = entry.find('span', {'class': 'paper-authors'})
         if authors_tag:

--- a/nips_download_parse.py
+++ b/nips_download_parse.py
@@ -17,8 +17,9 @@ for year in range(2006, 2024):
     url = "https://proceedings.neurips.cc/paper_files/paper/%d" % (year,)
     print("downloading proceedings from NeurIPS year %d..." % (year,))
 
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
     try:
-        with urllib.request.urlopen(url) as f:
+        with urllib.request.urlopen(req) as f:
             s = f.read()
     except Exception as e:
         print("error fetching year %d: %s, skipping..." % (year, e))
@@ -27,30 +28,32 @@ for year in range(2006, 2024):
     print("done. Parsing...")
     soup = BeautifulSoup(s, 'html.parser')
 
-    publication_section = soup.find('div', {'class': 'container-fluid'})
-    if not publication_section:
-        warnings.append("no publication section found for year %d" % (year,))
+    paper_list = soup.find('ul', {'class': 'paper-list'})
+    if not paper_list:
+        warnings.append("no paper-list found for year %d" % (year,))
         continue
 
     venue = 'NeurIPS %d' % (year,)
     old_count = len(pubs)
 
-    for entry in publication_section.find_all('li', {'class': 'none'}):
+    for entry in paper_list.find_all('li'):
         new_pub = {}
 
         title_tag = entry.find('a', {'title': 'paper title'})
-        if title_tag:
-            new_pub['title'] = title_tag.text.strip()
+        if not title_tag:
+            continue
 
-        authors_tag = entry.find('i')
+        new_pub['title'] = title_tag.text.strip()
+        new_pub['pdf'] = 'https://proceedings.neurips.cc' + title_tag['href']
+
+        authors_tag = entry.find('span', {'class': 'paper-authors'})
         if authors_tag:
             authors = authors_tag.text.strip().split(',')
             new_pub['authors'] = [author.strip() for author in authors]
 
-        if new_pub:
-            new_pub['venue'] = venue
-            new_pub['year'] = year
-            pubs.append(new_pub)
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
 
     print("read in %d publications for year %d." % (len(pubs) - old_count, year))
 

--- a/nips_download_parse.py
+++ b/nips_download_parse.py
@@ -1,117 +1,70 @@
 """
 Standalone helper script.
 
-Parses NIPS proceedings for years 2003-2010, creates list of dictionaries
-that store information about each publication, and saves the result as a 
+Parses NeurIPS proceedings, creates list of dictionaries
+that store information about each publication, and saves the result as a
 pickle in current directory called pubs_nips.
 """
 
-import urllib
-from BeautifulSoup import BeautifulSoup, Tag, NavigableString
+import urllib.request
+from bs4 import BeautifulSoup
 from repool_util import savePubs
 
 pubs = []
 warnings = []
-for num in range(16, 24):
-    year = 1987 + num
-    
-    url = "http://books.nips.cc/nips%d.html" % (num,)
-    print "downloading proceedings from NIPS year %d..." % (year,)
-    f = urllib.urlopen(url)
-    s = f.read()
-    f.close()
-    
-    print "done. Parsing..."
-    soup = BeautifulSoup(s)
-    soup = soup.find('table', {'width' : '600'}) # find the main table HTML
-    soup = soup.contents[0].contents[0] # descend down <tr> and then <td>
-    
-    # iterate over this giant linear dump they have on the proceedings site
-    venue = 'NIPS %d' % (year,)
-    new_pub = {}
+
+for year in range(2006, 2024):
+    url = "https://proceedings.neurips.cc/paper_files/paper/%d" % (year,)
+    print("downloading proceedings from NeurIPS year %d..." % (year,))
+
+    try:
+        with urllib.request.urlopen(url) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    publication_section = soup.find('div', {'class': 'container-fluid'})
+    if not publication_section:
+        warnings.append("no publication section found for year %d" % (year,))
+        continue
+
+    venue = 'NeurIPS %d' % (year,)
     old_count = len(pubs)
-    for item in soup.contents:
-    
-        if isinstance(item, Tag):
-            if item.name == 'b':
-                
-                # we stumbled by a new publication entry. If we were processing
-                # one before this, then commit that one first then continue
-                if new_pub:
-                    if not new_pub.has_key('authors'):
-                        warnings.append("oh oh no authors for publication... ")
-                    
-                    if not new_pub.has_key('title'):
-                        warnings.append("oh oh no title for publication... ")
-                    
-                    new_pub['venue'] = venue
-                    new_pub['year']= year
-                    pubs.append(new_pub)
-                
-                # start new publication dictionary
-                new_pub = {}
-                new_title = str(item.contents[0]) # descend down a <b> tag
-                new_title = new_title.replace('\n', '')
-                new_pub['title'] = new_title
-                
-            if item.name == 'a':
-                modifier = str(item.contents[0]).strip()
-                if modifier == '[pdf]':
-                    new_pub['pdf'] = str(item.attrs[0][1])
-                elif modifier == '[bibtex]':
-                    new_pub['bibtex'] = str(item.attrs[0][1])
-                elif modifier == '[correction]':
-                    new_pub['correction'] = str(item.attrs[0][1])
-                elif modifier == '[supplemental]':
-                    new_pub['supplemental'] = str(item.attrs[0][1])
-                elif modifier == '[slide]':
-                    new_pub['slide'] = str(item.attrs[0][1])
-                elif modifier == '[audio]':
-                    new_pub['audio'] = str(item.attrs[0][1])
-                elif modifier == '[ps.gz]':
-                    pass # ignore
-                elif modifier == '[djvu]':
-                    pass # ignore
-                else:
-                    warnings.append("warning: modifier %s skipped" %(modifier,))
-                
-        if isinstance(item, NavigableString):
-            if len(str(item))>3:
-                
-                # this is probably the line describing authors
-                author_str = str(item)
-                author_str = author_str.replace('\n', '') # remove newlines
-                author_list = author_str.split(',')
-                if new_pub.has_key('authors'):
-                    warnings.append("we're in trouble... %s, but already have "\
-                                    "%s" % (str(item), new_pub['authors']))
-                    
-                new_pub['authors'] = [x.strip() for x in author_list]
-        
-    # I hate myself a little for this
-    # TODO LATER_MAYBE: CODE CHUNK DUPLICATION
-    if not new_pub.has_key('authors'):
-        warnings.append("oh oh no authors for publication... ")
-    if not new_pub.has_key('title'):
-        warnings.append("oh oh no title for publication... ")
-    new_pub['venue'] = venue
-    new_pub['year']= year
-    pubs.append(new_pub)
-    
-    print "read in %d publications for year %d." % (len(pubs) - old_count, year)
-    
+
+    for entry in publication_section.find_all('li', {'class': 'none'}):
+        new_pub = {}
+
+        title_tag = entry.find('a', {'title': 'paper title'})
+        if title_tag:
+            new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = entry.find('i')
+        if authors_tag:
+            authors = authors_tag.text.strip().split(',')
+            new_pub['authors'] = [author.strip() for author in authors]
+
+        if new_pub:
+            new_pub['venue'] = venue
+            new_pub['year'] = year
+            pubs.append(new_pub)
+
+    print("read in %d publications for year %d." % (len(pubs) - old_count, year))
 
 # show warnings, if any were generated
-if len(warnings)>0:
-    print "%d warnings:" % (len(warnings),)
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
     for x in warnings:
-        print x
+        print(x)
 else:
-    print "No warnings generated."
+    print("No warnings generated.")
 
 # finally, save pickle as output
-print "read in a total of %d publications." % (len(pubs),)
+print("read in a total of %d publications." % (len(pubs),))
 fname = "pubs_nips"
-print "saving pickle in %s" % (fname,)
+print("saving pickle in %s" % (fname,))
 savePubs(fname, pubs)
-print "all done."
+print("all done.")

--- a/nsdi_download_parse.py
+++ b/nsdi_download_parse.py
@@ -1,0 +1,161 @@
+"""
+Standalone helper script.
+
+Parses NSDI (Networked Systems Design and Implementation) proceedings from
+usenix.org, creates list of dictionaries that store information about each
+publication, and saves the result as a pickle called pubs_nsdi.
+
+NSDI is held annually. The USENIX site has parseable technical-sessions
+pages from 2012 onward.
+"""
+
+import urllib.request
+import re
+import time
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://www.usenix.org"
+UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+      "AppleWebKit/537.36 (KHTML, like Gecko) "
+      "Chrome/120.0.0.0 Safari/537.36")
+
+# NSDI years with parseable technical-sessions pages on usenix.org.
+NSDI_YEARS = list(range(2012, 2026))
+
+# Delay between HTTP requests (seconds) to avoid rate-limiting.
+REQUEST_DELAY = 4
+
+pubs = []
+warnings = []
+
+
+def parse_authors_from_field(field_div):
+    """
+    Extract author names from a paper-people-text or presented-by field div.
+    Affiliations are wrapped in <em> tags, so we remove those first.
+    Author groups are separated by semicolons; authors within a group
+    are separated by commas and 'and'.
+    """
+    if field_div is None:
+        return []
+
+    field_item = field_div.find('div', class_='field-item')
+    if field_item is None:
+        field_item = field_div
+
+    # Remove <em> tags (affiliations) from a copy
+    import copy
+    fi = copy.copy(field_item)
+    for em in fi.find_all('em'):
+        em.decompose()
+
+    text = fi.get_text()
+    text = text.replace('\n', ' ').replace('\r', ' ')
+    text = text.replace('\xa0', ' ')  # non-breaking spaces
+
+    # Split by semicolons (group separator), then handle commas and 'and'
+    groups = text.split(';')
+    authors = []
+    for group in groups:
+        group = group.strip()
+        if not group:
+            continue
+        group = group.replace(' and ', ', ')
+        parts = [p.strip() for p in group.split(',')]
+        for p in parts:
+            p = p.strip()
+            if p and len(p) > 1:
+                authors.append(p)
+    return authors
+
+
+for year in NSDI_YEARS:
+    slug = "nsdi%d" % (year % 100)
+    url = "%s/conference/%s/technical-sessions" % (BASE_URL, slug)
+    venue = "NSDI %d" % year
+    print("downloading %s..." % venue)
+
+    req = urllib.request.Request(url, headers={'User-Agent': UA})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as f:
+            s = f.read()
+    except Exception as e:
+        warnings.append("error fetching %s: %s" % (venue, e))
+        print("error fetching %s: %s, skipping..." % (venue, e))
+        time.sleep(REQUEST_DELAY)
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+
+    # Papers are in elements (article or div) with class 'node-paper'.
+    papers = soup.find_all(class_='node-paper')
+
+    for paper in papers:
+        # Title is in an h2 tag containing an <a> link
+        h2 = paper.find('h2')
+        if not h2:
+            continue
+        a = h2.find('a')
+        if not a:
+            continue
+
+        href = a.get('href', '')
+        title = a.get_text(strip=True)
+        if not title:
+            continue
+
+        # Skip non-NSDI entries (e.g. joint keynotes)
+        if '/conference/' in href and ('/%s/' % slug) not in href:
+            continue
+
+        # Skip keynotes, opening remarks, etc.
+        if 'keynote' in href.lower() or 'opening-remarks' in href.lower():
+            continue
+
+        new_pub = {'title': title}
+
+        # Authors: look for field-paper-people-text first, then field-presented-by
+        author_div = paper.find(
+            'div', class_=re.compile(r'field-name-field-paper-people-text'))
+        if not author_div:
+            author_div = paper.find(
+                'div', class_=re.compile(r'field-name-field-presented-by'))
+
+        authors = parse_authors_from_field(author_div)
+        if authors:
+            new_pub['authors'] = authors
+
+        # PDF link from the media section
+        pdf_span = paper.find('span', class_='pdf')
+        if pdf_span:
+            pdf_a = pdf_span.find('a')
+            if pdf_a and pdf_a.get('href'):
+                pdf_href = pdf_a['href']
+                if not pdf_href.startswith('http'):
+                    pdf_href = BASE_URL + pdf_href
+                new_pub['pdf'] = pdf_href
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for %s." % (len(pubs) - old_count, venue))
+    time.sleep(REQUEST_DELAY)
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_nsdi"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/osdi_download_parse.py
+++ b/osdi_download_parse.py
@@ -1,0 +1,162 @@
+"""
+Standalone helper script.
+
+Parses OSDI (Operating Systems Design and Implementation) proceedings from
+usenix.org, creates list of dictionaries that store information about each
+publication, and saves the result as a pickle called pubs_osdi.
+
+OSDI was biennial (even years) through 2020, then became annual.
+The USENIX site has parseable technical-sessions pages from 2012 onward.
+"""
+
+import urllib.request
+import re
+import time
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://www.usenix.org"
+UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+      "AppleWebKit/537.36 (KHTML, like Gecko) "
+      "Chrome/120.0.0.0 Safari/537.36")
+
+# OSDI years with parseable technical-sessions pages on usenix.org.
+# Biennial (even) 2012-2020, then annual 2021 onward.
+OSDI_YEARS = list(range(2012, 2020, 2)) + list(range(2020, 2026))
+
+# Delay between HTTP requests (seconds) to avoid rate-limiting.
+REQUEST_DELAY = 4
+
+pubs = []
+warnings = []
+
+
+def parse_authors_from_field(field_div):
+    """
+    Extract author names from a paper-people-text or presented-by field div.
+    Affiliations are wrapped in <em> tags, so we remove those first.
+    Author groups are separated by semicolons; authors within a group
+    are separated by commas and 'and'.
+    """
+    if field_div is None:
+        return []
+
+    field_item = field_div.find('div', class_='field-item')
+    if field_item is None:
+        field_item = field_div
+
+    # Remove <em> tags (affiliations) from a copy
+    import copy
+    fi = copy.copy(field_item)
+    for em in fi.find_all('em'):
+        em.decompose()
+
+    text = fi.get_text()
+    text = text.replace('\n', ' ').replace('\r', ' ')
+    text = text.replace('\xa0', ' ')  # non-breaking spaces
+
+    # Split by semicolons (group separator), then handle commas and 'and'
+    groups = text.split(';')
+    authors = []
+    for group in groups:
+        group = group.strip()
+        if not group:
+            continue
+        group = group.replace(' and ', ', ')
+        parts = [p.strip() for p in group.split(',')]
+        for p in parts:
+            p = p.strip()
+            if p and len(p) > 1:
+                authors.append(p)
+    return authors
+
+
+for year in OSDI_YEARS:
+    slug = "osdi%d" % (year % 100)
+    url = "%s/conference/%s/technical-sessions" % (BASE_URL, slug)
+    venue = "OSDI %d" % year
+    print("downloading %s..." % venue)
+
+    req = urllib.request.Request(url, headers={'User-Agent': UA})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as f:
+            s = f.read()
+    except Exception as e:
+        warnings.append("error fetching %s: %s" % (venue, e))
+        print("error fetching %s: %s, skipping..." % (venue, e))
+        time.sleep(REQUEST_DELAY)
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+
+    # Papers are in elements (article or div) with class 'node-paper'.
+    papers = soup.find_all(class_='node-paper')
+
+    for paper in papers:
+        # Title is in an h2 tag containing an <a> link
+        h2 = paper.find('h2')
+        if not h2:
+            continue
+        a = h2.find('a')
+        if not a:
+            continue
+
+        href = a.get('href', '')
+        title = a.get_text(strip=True)
+        if not title:
+            continue
+
+        # Skip non-OSDI entries (e.g. joint keynotes from ATC)
+        if '/conference/' in href and ('/%s/' % slug) not in href:
+            continue
+
+        # Skip keynotes, opening remarks, etc.
+        if 'keynote' in href.lower() or 'opening-remarks' in href.lower():
+            continue
+
+        new_pub = {'title': title}
+
+        # Authors: look for field-paper-people-text first, then field-presented-by
+        author_div = paper.find(
+            'div', class_=re.compile(r'field-name-field-paper-people-text'))
+        if not author_div:
+            author_div = paper.find(
+                'div', class_=re.compile(r'field-name-field-presented-by'))
+
+        authors = parse_authors_from_field(author_div)
+        if authors:
+            new_pub['authors'] = authors
+
+        # PDF link from the media section
+        pdf_span = paper.find('span', class_='pdf')
+        if pdf_span:
+            pdf_a = pdf_span.find('a')
+            if pdf_a and pdf_a.get('href'):
+                pdf_href = pdf_a['href']
+                if not pdf_href.startswith('http'):
+                    pdf_href = BASE_URL + pdf_href
+                new_pub['pdf'] = pdf_href
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for %s." % (len(pubs) - old_count, venue))
+    time.sleep(REQUEST_DELAY)
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_osdi"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/pdf_read.py
+++ b/pdf_read.py
@@ -2,39 +2,23 @@
 Functions for PDF parsing tools and utils
 """
 
-from pdfminer.pdfinterp import PDFResourceManager, process_pdf
-from pdfminer.converter import TextConverter
-from pdfminer.layout import LAParams
-from cStringIO import StringIO
+from pdfminer.high_level import extract_text
+from io import BytesIO
+import urllib.request
 
-import urllib
-
-def convertPDF(pdf_path, codec='ascii'):
+def convertPDF(pdf_path, codec='utf-8'):
     """
     Takes path to a PDF and returns the text inside it as string
-    
-    pdf_path: string indicating path to a .pdf file. Can also be a URL starting 
+
+    pdf_path: string indicating path to a .pdf file. Can also be a URL starting
               with 'http'
     codec: can be 'ascii', 'utf-8', ...
     returns string of the pdf, as it comes out raw from PDFMiner
     """
-    
+
     if pdf_path[:4] == 'http':
-        print 'first downloading %s ...' % (pdf_path,)
-        urllib.urlretrieve(pdf_path, 'temp.pdf')
+        print('first downloading %s ...' % (pdf_path,))
+        urllib.request.urlretrieve(pdf_path, 'temp.pdf')
         pdf_path = 'temp.pdf'
-    
-    rsrcmgr = PDFResourceManager()
-    retstr = StringIO()
-    laparams = LAParams()
-    device = TextConverter(rsrcmgr, retstr, codec=codec, laparams=laparams)
-    
-    fp = file(pdf_path, 'rb')
-    process_pdf(rsrcmgr, device, fp)
-    fp.close()
-    device.close()
-    
-    str = retstr.getvalue()
-    retstr.close()
-    
-    return str
+
+    return extract_text(pdf_path)

--- a/pdf_read.py
+++ b/pdf_read.py
@@ -3,22 +3,23 @@ Functions for PDF parsing tools and utils
 """
 
 from pdfminer.high_level import extract_text
-from io import BytesIO
+import tempfile
 import urllib.request
 
-def convertPDF(pdf_path, codec='utf-8'):
+def convertPDF(pdf_path):
     """
     Takes path to a PDF and returns the text inside it as string
 
     pdf_path: string indicating path to a .pdf file. Can also be a URL starting
               with 'http'
-    codec: can be 'ascii', 'utf-8', ...
     returns string of the pdf, as it comes out raw from PDFMiner
     """
 
     if pdf_path[:4] == 'http':
         print('first downloading %s ...' % (pdf_path,))
-        urllib.request.urlretrieve(pdf_path, 'temp.pdf')
-        pdf_path = 'temp.pdf'
+        with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as tmp:
+            with urllib.request.urlopen(pdf_path, timeout=30) as resp:
+                tmp.write(resp.read())
+            pdf_path = tmp.name
 
     return extract_text(pdf_path)

--- a/pdf_read.py
+++ b/pdf_read.py
@@ -3,6 +3,7 @@ Functions for PDF parsing tools and utils
 """
 
 from pdfminer.high_level import extract_text
+import os
 import tempfile
 import urllib.request
 
@@ -17,9 +18,15 @@ def convertPDF(pdf_path):
 
     if pdf_path[:4] == 'http':
         print('first downloading %s ...' % (pdf_path,))
-        with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as tmp:
-            with urllib.request.urlopen(pdf_path, timeout=30) as resp:
+        req = urllib.request.Request(pdf_path, headers={'User-Agent': 'Mozilla/5.0'})
+        tmp = tempfile.NamedTemporaryFile(suffix='.pdf', delete=False)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
                 tmp.write(resp.read())
-            pdf_path = tmp.name
+            tmp.close()
+            return extract_text(tmp.name)
+        finally:
+            tmp.close()
+            os.unlink(tmp.name)
 
     return extract_text(pdf_path)

--- a/pgm_download_parse.py
+++ b/pgm_download_parse.py
@@ -1,0 +1,82 @@
+"""
+Standalone helper script.
+
+Parses PGM (Probabilistic Graphical Models) proceedings from
+proceedings.mlr.press, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle in current directory
+called pubs_pgm.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+PGM_VOLUMES = {
+    52: 2016,
+    72: 2018,
+    138: 2020,
+    186: 2022,
+    246: 2024,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(PGM_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading PGM %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'PGM %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for PGM %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_pgm"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/repool_analysis.py
+++ b/repool_analysis.py
@@ -21,7 +21,7 @@ def publicationSimilarityNaive(train_pubs, test_pub):
 
     scores = [-1 for i in range(len(train_pubs))]
     wnum_test = len(test_pub['pdf_text'])
-    words = test_pub['pdf_text'].keys()
+    words = set(test_pub['pdf_text'].keys())
 
     for i, p in enumerate(train_pubs):
         if(i % 100 == 0): print("%d/%d..." % (i, len(train_pubs)))
@@ -31,8 +31,7 @@ def publicationSimilarityNaive(train_pubs, test_pub):
         # find score of the match
         wnum_train = len(p['pdf_text'])
 
-        # a random thing I just thought of 5 seconds ago
-        overlap = sum([1 for x in words if x in p['pdf_text'].keys()])
+        overlap = len(words & set(p['pdf_text'].keys()))
         scores[i] = 2.0 * overlap / (wnum_train + wnum_test)
 
     return scores

--- a/repool_analysis.py
+++ b/repool_analysis.py
@@ -31,7 +31,7 @@ def publicationSimilarityNaive(train_pubs, test_pub):
         # find score of the match
         wnum_train = len(p['pdf_text'])
 
-        overlap = len(words & set(p['pdf_text'].keys()))
+        overlap = sum(1 for w in words if w in p['pdf_text'])
         scores[i] = 2.0 * overlap / (wnum_train + wnum_test)
 
     return scores

--- a/repool_analysis.py
+++ b/repool_analysis.py
@@ -1,39 +1,38 @@
-""" 
-Functions: some stage 3 functions. Analyze pubs_ files and 
+"""
+Functions: some stage 3 functions. Analyze pubs_ files and
 provide more high-level functionality
 """
 
 def publicationSimilarityNaive(train_pubs, test_pub):
-    """ 
+    """
     Find similarities of publications to some particular publication,
     using a very simple overlap method.
-    
+
     train_pubs: list of publications
-    test_pub: a publication to compare to. Must contain 'pdf_text' key with the 
+    test_pub: a publication to compare to. Must contain 'pdf_text' key with the
               bag of words that occur in that publication
-    
+
     returns list of (scores, one for each of the train_pubs. Returns -1 for
             any score where a publication does not have the pdf_text available.
     """
-    
-    if not test_pub.has_key('pdf_text'): 
+
+    if 'pdf_text' not in test_pub:
         return []
-    
+
     scores = [-1 for i in range(len(train_pubs))]
     wnum_test = len(test_pub['pdf_text'])
     words = test_pub['pdf_text'].keys()
-    
-    for i,p in enumerate(train_pubs):
-        if(i%100==0): print "%d/%d..." % (i, len(train_pubs))
-        
-        if not p.has_key('pdf_text'): continue
-        
-        #find score of the match
+
+    for i, p in enumerate(train_pubs):
+        if(i % 100 == 0): print("%d/%d..." % (i, len(train_pubs)))
+
+        if 'pdf_text' not in p: continue
+
+        # find score of the match
         wnum_train = len(p['pdf_text'])
-        
-        #a random thing I just thought of 5 seconds ago
+
+        # a random thing I just thought of 5 seconds ago
         overlap = sum([1 for x in words if x in p['pdf_text'].keys()])
         scores[i] = 2.0 * overlap / (wnum_train + wnum_test)
-        
+
     return scores
-    

--- a/repool_util.py
+++ b/repool_util.py
@@ -59,7 +59,7 @@ def stringToWordDictionary(str):
     stopwords = ['the', 'and', 'for', 'that', 'can', 'this', 'which', \
                  'where', 'are', 'from', 'our', 'not', 'with', 'use', \
                  'then', 'than', 'but', 'have', 'was', 'were', 'these', \
-                 'each', 'used', 'set', 'such', 'using', 'when', 'those' \
+                 'each', 'used', 'set', 'such', 'using', 'when', 'those',
                  'may', 'also']
     
     #cid is some kind of artifact from the pdf conversion that occurs very often

--- a/repool_util.py
+++ b/repool_util.py
@@ -1,21 +1,20 @@
 """ Functions: useful general utils """
 
-import cPickle
+import pickle
 import re
-from os import startfile
+import webbrowser
 
 def savePubs(filename, pubs_to_save):
-    """ 
+    """
     save a list of publications into a file using Python's pickle
     filename: string
     pubs_to_save: List of Publication objects
-    
+
     returns nothing
     """
-    
-    file = open(filename, 'w')
-    cPickle.dump(pubs_to_save, file)
-    file.close()
+
+    with open(filename, 'wb') as f:
+        pickle.dump(pubs_to_save, f)
 
 def loadPubs(filename):
     """
@@ -23,23 +22,22 @@ def loadPubs(filename):
     filename: string
     returns list of dictionaries, each representing a Publication
     """
-    
-    unpicklefile = open(filename, 'r')
-    pubs = cPickle.load(unpicklefile)
-    unpicklefile.close()
+
+    with open(filename, 'rb') as f:
+        pubs = pickle.load(f)
     return pubs
-    
+
 def openPDFs(pdf_lst):
     """
-    uses an os call to open a list of pdfs
+    uses webbrowser to open a list of pdfs
     pdf_lst: list of strings: paths (or urls) of pdfs to open
     """
     if len(pdf_lst)>10:
-        print "more than 10? that can't be right. Request denied."
+        print("more than 10? that can't be right. Request denied.")
         return
-        
+
     for x in pdf_lst:
-        startfile(x)
+        webbrowser.open(x)
         
 def stringToWordDictionary(str):
     """

--- a/repool_util.py
+++ b/repool_util.py
@@ -65,9 +65,7 @@ def stringToWordDictionary(str):
     #cid is some kind of artifact from the pdf conversion that occurs very often
     stopwords.extend(['cid'])
     
-    keys = d.keys()
-    for k in keys:
-        if k in stopwords: 
-            del d[k]
+    for k in stopwords:
+        d.pop(k, None)
     
     return d

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+pdfminer.six

--- a/rss_download_parse.py
+++ b/rss_download_parse.py
@@ -1,0 +1,105 @@
+"""
+Standalone helper script.
+
+Parses RSS (Robotics: Science and Systems) proceedings from
+roboticsproceedings.org, creates list of dictionaries that store
+information about each publication, and saves the result as a pickle
+in current directory called pubs_rss.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://www.roboticsproceedings.org"
+
+# RSS I (2005) through RSS XXI (2025)
+RSS_EDITIONS = {}
+for n in range(1, 22):
+    year = 2004 + n
+    key = "rss%02d" % n
+    RSS_EDITIONS[key] = year
+
+pubs = []
+warnings = []
+
+for edition, year in sorted(RSS_EDITIONS.items(), key=lambda x: x[1]):
+    url = "%s/%s/index.html" % (BASE_URL, edition)
+    print("downloading RSS %d (%s)..." % (year, edition))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching %s: %s, skipping..." % (edition, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = "RSS %d" % year
+
+    content_div = soup.find('div', {'class': 'content'})
+    if not content_div:
+        warnings.append("no content div found for %s" % edition)
+        continue
+
+    table = content_div.find('table')
+    if not table:
+        warnings.append("no table found for %s" % edition)
+        continue
+
+    for tr in table.find_all('tr'):
+        tds = tr.find_all('td')
+        if not tds:
+            continue
+
+        first_td = tds[0]
+
+        # skip spacer rows
+        text = first_td.get_text(strip=True)
+        if not text or text == '\xa0' or text == '&nbsp':
+            continue
+
+        title_tag = first_td.find('a')
+        if not title_tag:
+            continue
+
+        new_pub = {}
+        new_pub['title'] = title_tag.get_text(strip=True)
+
+        authors_tag = first_td.find('i')
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        # PDF link is in the second td
+        if len(tds) > 1:
+            pdf_tag = tds[1].find('a')
+            if pdf_tag and pdf_tag.get('href'):
+                pdf_href = pdf_tag['href']
+                if not pdf_href.startswith('http'):
+                    pdf_href = "%s/%s/%s" % (BASE_URL, edition, pdf_href)
+                new_pub['pdf'] = pdf_href
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for RSS %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_rss"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/semeval_download_parse.py
+++ b/semeval_download_parse.py
@@ -1,0 +1,88 @@
+"""
+Standalone helper script.
+
+Parses SemEval (International Workshop on Semantic Evaluation) proceedings from
+aclanthology.org, creates list of dictionaries that store information
+about each publication, and saves the result as a pickle called pubs_semeval.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://aclanthology.org"
+
+pubs = []
+warnings = []
+
+for year in range(2007, 2027):
+    url = "%s/events/semeval-%d/" % (BASE_URL, year)
+    print("downloading SemEval %d..." % (year,))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    venue = 'SemEval %d' % (year,)
+    old_count = len(pubs)
+
+    for strong in soup.find_all('strong'):
+        a = strong.find('a', class_='align-middle')
+        if not a:
+            continue
+
+        title = a.text.strip()
+        if not title:
+            continue
+
+        # skip proceedings headers / reports
+        href = a.get('href', '')
+        if href.endswith('.0/') or 'report' in href:
+            continue
+
+        new_pub = {'title': title}
+
+        # authors are <a href="/people/..."> in the parent <span>
+        span = strong.parent
+        if span:
+            authors = []
+            for author_a in span.find_all('a'):
+                author_href = author_a.get('href', '')
+                if '/people/' in author_href:
+                    authors.append(author_a.text.strip())
+            if authors:
+                new_pub['authors'] = authors
+
+            # PDF link - look in the surrounding div
+            container = span.parent
+            if container:
+                pdf_a = container.find('a', {'title': 'Open PDF'})
+                if pdf_a:
+                    new_pub['pdf'] = pdf_a['href']
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for SemEval %d." % (len(pubs) - old_count, year))
+
+# show warnings
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_semeval"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/tests/test_google_search.py
+++ b/tests/test_google_search.py
@@ -1,0 +1,32 @@
+"""Tests for google_search.py (rewritten from dead Google AJAX API)"""
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from google_search import getPDFURL
+
+
+class TestGetPDFURL:
+    def test_returns_notfound_on_no_results(self):
+        fake_html = '<html><body>No results</body></html>'
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = fake_html.encode('utf-8')
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch('google_search.urllib.request.urlopen', return_value=mock_resp):
+            assert getPDFURL('nonexistent paper') == 'notfound'
+
+    def test_extracts_pdf_link(self):
+        fake_html = '<a href="https://example.com/paper.pdf">link</a>'
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = fake_html.encode('utf-8')
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch('google_search.urllib.request.urlopen', return_value=mock_resp):
+            assert getPDFURL('some paper') == 'https://example.com/paper.pdf'
+
+    def test_returns_notfound_on_error(self):
+        with patch('google_search.urllib.request.urlopen', side_effect=Exception('fail')):
+            assert getPDFURL('some paper') == 'notfound'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,160 @@
+"""
+Integration tests that hit real conference proceedings sites.
+These verify that scrapers still work against current HTML structures.
+
+Run with: pytest tests/test_integration.py -v
+Slower than unit tests (~30s) as they make real HTTP requests.
+"""
+
+import os
+import sys
+import urllib.request
+import pytest
+from bs4 import BeautifulSoup
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+HEADERS = {'User-Agent': 'Mozilla/5.0'}
+
+
+def fetch(url, timeout=15):
+    req = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=timeout) as f:
+        return f.read()
+
+
+class TestNeurIPS:
+    """Test NeurIPS scraper against proceedings.neurips.cc"""
+
+    def test_paper_list_exists(self):
+        html = fetch('https://proceedings.neurips.cc/paper_files/paper/2023')
+        soup = BeautifulSoup(html, 'html.parser')
+        paper_list = soup.find('ul', {'class': 'paper-list'})
+        assert paper_list is not None, "paper-list element not found"
+
+    def test_paper_has_title(self):
+        html = fetch('https://proceedings.neurips.cc/paper_files/paper/2023')
+        soup = BeautifulSoup(html, 'html.parser')
+        paper_list = soup.find('ul', {'class': 'paper-list'})
+        first_paper = paper_list.find('a', {'title': 'paper title'})
+        assert first_paper is not None
+        assert len(first_paper.text.strip()) > 5
+
+    def test_pdf_url_is_valid(self):
+        """PDF URL should point to actual PDF, not abstract page."""
+        html = fetch('https://proceedings.neurips.cc/paper_files/paper/2023')
+        soup = BeautifulSoup(html, 'html.parser')
+        paper_list = soup.find('ul', {'class': 'paper-list'})
+        first_link = paper_list.find('a', {'title': 'paper title'})
+        page_url = 'https://proceedings.neurips.cc' + first_link['href']
+        pdf_url = page_url.replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
+        assert pdf_url.endswith('.pdf'), "PDF URL should end with .pdf"
+        assert '/file/' in pdf_url
+
+
+class TestICML:
+    """Test ICML scraper against proceedings.mlr.press"""
+
+    def test_papers_exist(self):
+        html = fetch('https://proceedings.mlr.press/v235/')
+        soup = BeautifulSoup(html, 'html.parser')
+        papers = soup.find_all('div', {'class': 'paper'})
+        assert len(papers) > 100, "Expected 100+ papers for ICML 2024"
+
+    def test_paper_structure(self):
+        html = fetch('https://proceedings.mlr.press/v235/')
+        soup = BeautifulSoup(html, 'html.parser')
+        paper = soup.find('div', {'class': 'paper'})
+        title = paper.find('p', {'class': 'title'})
+        authors = paper.find('span', {'class': 'authors'})
+        assert title is not None and len(title.text.strip()) > 0
+        assert authors is not None and len(authors.text.strip()) > 0
+
+
+class TestCVPR:
+    """Test CVPR scraper against openaccess.thecvf.com"""
+
+    def test_papers_exist(self):
+        html = fetch('https://openaccess.thecvf.com/CVPR2024?day=all')
+        soup = BeautifulSoup(html, 'html.parser')
+        papers = soup.find_all('dt', {'class': 'ptitle'})
+        assert len(papers) > 100, "Expected 100+ papers for CVPR 2024"
+
+    def test_paper_has_pdf_link(self):
+        html = fetch('https://openaccess.thecvf.com/CVPR2024?day=all')
+        soup = BeautifulSoup(html, 'html.parser')
+        dt = soup.find('dt', {'class': 'ptitle'})
+        # find next dd with pdf link
+        for dd in dt.find_next_siblings('dd'):
+            for a in dd.find_all('a'):
+                if a.get('href', '').endswith('.pdf'):
+                    assert True
+                    return
+        pytest.fail("No PDF link found for first paper")
+
+
+class TestACLAnthology:
+    """Test ACL Anthology scrapers"""
+
+    def test_acl_papers_exist(self):
+        html = fetch('https://aclanthology.org/events/acl-2024/')
+        soup = BeautifulSoup(html, 'html.parser')
+        papers = soup.find_all('strong')
+        titled = [s for s in papers if s.find('a', class_='align-middle')]
+        assert len(titled) > 100, "Expected 100+ papers for ACL 2024"
+
+    def test_paper_has_pdf(self):
+        html = fetch('https://aclanthology.org/events/acl-2024/')
+        soup = BeautifulSoup(html, 'html.parser')
+        pdf_link = soup.find('a', {'title': 'Open PDF'})
+        assert pdf_link is not None
+        assert pdf_link['href'].endswith('.pdf')
+
+
+class TestAAI:
+    """Test AAAI scraper against ojs.aaai.org"""
+
+    def test_issue_has_papers(self):
+        html = fetch('https://ojs.aaai.org/index.php/AAAI/issue/view/624')
+        soup = BeautifulSoup(html, 'html.parser')
+        articles = soup.find_all('div', class_='obj_article_summary')
+        assert len(articles) > 50, "Expected 50+ papers in AAAI issue"
+
+    def test_paper_structure(self):
+        html = fetch('https://ojs.aaai.org/index.php/AAAI/issue/view/624')
+        soup = BeautifulSoup(html, 'html.parser')
+        article = soup.find('div', class_='obj_article_summary')
+        title = article.find('h3', class_='title')
+        authors = article.find('div', class_='authors')
+        assert title is not None
+        assert authors is not None
+
+
+class TestOpenReview:
+    """Test ICLR scraper against OpenReview API"""
+
+    def test_api_returns_papers(self):
+        import json
+        url = 'https://api2.openreview.net/notes?content.venueid=ICLR.cc/2024/Conference&limit=5'
+        try:
+            req = urllib.request.Request(url)
+            with urllib.request.urlopen(req, timeout=15) as f:
+                data = json.loads(f.read())
+            assert 'notes' in data
+            assert len(data['notes']) > 0
+        except urllib.error.HTTPError as e:
+            if e.code == 403:
+                pytest.skip("OpenReview API blocked this request (403)")
+            raise
+
+
+class TestPDFRead:
+    """Test PDF download and extraction on a real PDF."""
+
+    def test_convert_real_pdf(self):
+        from pdf_read import convertPDF
+        # Use a known working PDF URL from GitHub (PMLR hosts PDFs there)
+        url = 'https://raw.githubusercontent.com/mlresearch/v235/main/assets/abad-rocamora24a/abad-rocamora24a.pdf'
+        text = convertPDF(url)
+        assert len(text) > 100, "Expected substantial text from PDF"
+        assert not os.path.exists('temp.pdf'), "Should not create temp.pdf"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,6 +14,11 @@ from bs4 import BeautifulSoup
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+pytestmark = pytest.mark.skipif(
+    os.environ.get('RUN_INTEGRATION_TESTS') != '1',
+    reason='Set RUN_INTEGRATION_TESTS=1 to run'
+)
+
 HEADERS = {'User-Agent': 'Mozilla/5.0'}
 
 

--- a/tests/test_pdf_read.py
+++ b/tests/test_pdf_read.py
@@ -1,0 +1,55 @@
+"""Tests for pdf_read.py"""
+
+import os
+import sys
+import tempfile
+import pytest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from pdf_read import convertPDF
+
+
+class TestConvertPDF:
+    def test_no_codec_parameter(self):
+        """convertPDF should not accept a codec parameter (removed in review)."""
+        import inspect
+        sig = inspect.signature(convertPDF)
+        assert 'codec' not in sig.parameters
+
+    def test_uses_tempfile_for_urls(self):
+        """URLs should be downloaded to a temp file, not fixed temp.pdf."""
+        with patch('pdf_read.urllib.request.urlopen') as mock_urlopen, \
+             patch('pdf_read.extract_text', return_value='text'):
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = b'%PDF-fake'
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+
+            result = convertPDF('http://example.com/paper.pdf')
+            assert result == 'text'
+
+            # verify urlopen was called with timeout
+            call_args = mock_urlopen.call_args
+            assert call_args[1].get('timeout', call_args[0][1] if len(call_args[0]) > 1 else None) == 30
+
+    def test_local_file(self):
+        """Local PDF paths should be passed directly to extract_text."""
+        with patch('pdf_read.extract_text', return_value='extracted text') as mock_extract:
+            result = convertPDF('/some/local/file.pdf')
+            assert result == 'extracted text'
+            mock_extract.assert_called_once_with('/some/local/file.pdf')
+
+    def test_no_temp_pdf_file_created(self):
+        """Should not create a fixed 'temp.pdf' file."""
+        with patch('pdf_read.urllib.request.urlopen') as mock_urlopen, \
+             patch('pdf_read.extract_text', return_value='text'):
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = b'%PDF-fake'
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+
+            convertPDF('http://example.com/paper.pdf')
+            assert not os.path.exists('temp.pdf')

--- a/tests/test_repool_analysis.py
+++ b/tests/test_repool_analysis.py
@@ -1,0 +1,57 @@
+"""Tests for repool_analysis.py"""
+
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from repool_analysis import publicationSimilarityNaive
+
+
+class TestPublicationSimilarityNaive:
+    def test_identical_papers(self):
+        pub = {'pdf_text': {'deep': 5, 'learning': 3, 'neural': 2}}
+        scores = publicationSimilarityNaive([pub], pub)
+        assert len(scores) == 1
+        assert scores[0] == pytest.approx(1.0)
+
+    def test_no_overlap(self):
+        test = {'pdf_text': {'quantum': 1, 'physics': 1}}
+        train = [{'pdf_text': {'cooking': 1, 'recipe': 1}}]
+        scores = publicationSimilarityNaive(train, test)
+        assert scores[0] == pytest.approx(0.0)
+
+    def test_partial_overlap(self):
+        test = {'pdf_text': {'deep': 5, 'learning': 3, 'neural': 2}}
+        train = [{'pdf_text': {'deep': 2, 'learning': 1, 'vision': 4}}]
+        scores = publicationSimilarityNaive(train, test)
+        # overlap=2 (deep, learning), total words = 3+3=6
+        assert scores[0] == pytest.approx(2.0 * 2 / 6)
+
+    def test_missing_pdf_text_in_test(self):
+        test = {'title': 'No text'}
+        train = [{'pdf_text': {'word': 1}}]
+        scores = publicationSimilarityNaive(train, test)
+        assert scores == []
+
+    def test_missing_pdf_text_in_train(self):
+        test = {'pdf_text': {'word': 1}}
+        train = [{'title': 'No text'}, {'pdf_text': {'word': 1}}]
+        scores = publicationSimilarityNaive(train, test)
+        assert scores[0] == -1
+        assert scores[1] > 0
+
+    def test_uses_set_intersection(self):
+        """Verify the set-based overlap works correctly with many words."""
+        words_a = {('word%d' % i): 1 for i in range(100)}
+        words_b = {('word%d' % i): 1 for i in range(50, 150)}
+        test = {'pdf_text': words_a}
+        train = [{'pdf_text': words_b}]
+        scores = publicationSimilarityNaive(train, test)
+        # overlap = 50 words (word50-word99), total = 100+100 = 200
+        assert scores[0] == pytest.approx(2.0 * 50 / 200)
+
+    def test_empty_train(self):
+        test = {'pdf_text': {'word': 1}}
+        scores = publicationSimilarityNaive([], test)
+        assert scores == []

--- a/tests/test_repool_util.py
+++ b/tests/test_repool_util.py
@@ -1,0 +1,87 @@
+"""Tests for repool_util.py"""
+
+import os
+import sys
+import tempfile
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from repool_util import savePubs, loadPubs, stringToWordDictionary
+
+
+class TestSaveLoadPubs:
+    def test_roundtrip(self, tmp_path):
+        pubs = [
+            {'title': 'Paper One', 'authors': ['Alice', 'Bob'], 'year': 2024, 'venue': 'NeurIPS 2024'},
+            {'title': 'Paper Two', 'authors': ['Charlie'], 'year': 2023, 'venue': 'ICML 2023'},
+        ]
+        path = str(tmp_path / "pubs_test")
+        savePubs(path, pubs)
+        loaded = loadPubs(path)
+        assert len(loaded) == 2
+        assert loaded[0]['title'] == 'Paper One'
+        assert loaded[1]['authors'] == ['Charlie']
+
+    def test_empty_list(self, tmp_path):
+        path = str(tmp_path / "pubs_empty")
+        savePubs(path, [])
+        loaded = loadPubs(path)
+        assert loaded == []
+
+    def test_binary_mode(self, tmp_path):
+        """Verify pickle files are written in binary mode."""
+        path = str(tmp_path / "pubs_bin")
+        savePubs(path, [{'title': 'test'}])
+        with open(path, 'rb') as f:
+            header = f.read(2)
+        # pickle protocol 2+ starts with \x80
+        assert header[0] == 0x80
+
+
+class TestStringToWordDictionary:
+    def test_basic(self):
+        d = stringToWordDictionary("hello world hello")
+        assert d['hello'] == 2
+        assert d['world'] == 1
+
+    def test_stopwords_removed(self):
+        d = stringToWordDictionary("the quick brown fox and the lazy dog")
+        assert 'the' not in d
+        assert 'and' not in d
+        assert 'quick' in d
+        assert 'brown' in d
+
+    def test_short_words_filtered(self):
+        d = stringToWordDictionary("I am a big fan of AI")
+        # words with len <= 2 should be filtered
+        assert 'am' not in d
+        assert 'big' in d
+        assert 'fan' in d
+
+    def test_case_insensitive(self):
+        d = stringToWordDictionary("Hello HELLO hello")
+        assert d['hello'] == 3
+
+    def test_cid_removed(self):
+        """cid is a PDF artifact that should be removed."""
+        d = stringToWordDictionary("some text with cid artifacts cid")
+        assert 'cid' not in d
+
+    def test_those_and_may_separate(self):
+        """Regression: 'those' and 'may' were concatenated due to missing comma."""
+        d = stringToWordDictionary("those may also appear here often")
+        assert 'thosemay' not in d
+        assert 'those' not in d  # stopword
+        assert 'may' not in d    # stopword
+        assert 'also' not in d   # stopword
+
+    def test_empty_string(self):
+        d = stringToWordDictionary("")
+        assert d == {}
+
+    def test_no_dict_mutation_error(self):
+        """Regression: dict changed size during iteration in Python 3."""
+        text = "the and for that can this which where are from"
+        d = stringToWordDictionary(text)
+        # all stopwords, should return empty dict
+        assert d == {}

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -1,0 +1,71 @@
+"""Tests for scraper utilities and common patterns."""
+
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestScraperFetchTimeout:
+    """Verify scrapers that use fetch() have timeout and proper exception handling."""
+
+    def _check_fetch_in_file(self, filepath):
+        with open(filepath) as f:
+            content = f.read()
+
+        if 'def fetch(' not in content:
+            pytest.skip("no fetch() function in %s" % filepath)
+
+        # check timeout in urlopen
+        assert 'timeout=' in content, \
+            "%s: fetch() should use timeout in urlopen" % filepath
+
+        # check no bare except
+        lines = content.split('\n')
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped == 'except:':
+                pytest.fail("%s line %d: bare 'except:' should be 'except Exception:'" % (filepath, i+1))
+
+    def test_cvpr_fetch(self):
+        self._check_fetch_in_file('cvpr_download_parse.py')
+
+    def test_iccv_fetch(self):
+        self._check_fetch_in_file('iccv_download_parse.py')
+
+    def test_wacv_fetch(self):
+        self._check_fetch_in_file('wacv_download_parse.py')
+
+
+class TestNipsAddPdftext:
+    """Test URL rewriting logic in nips_add_pdftext.py."""
+
+    def test_abstract_url_rewrite(self):
+        """Abstract URLs should be rewritten to PDF URLs."""
+        url = 'https://proceedings.neurips.cc/paper_files/paper/2024/hash/abc123-Abstract-Conference.html'
+        if '-Abstract-Conference.html' in url:
+            pdf_url = url.replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
+        else:
+            pdf_url = url
+        assert pdf_url.endswith('-Paper-Conference.pdf')
+        assert '/file/' in pdf_url
+        assert '/hash/' not in pdf_url
+
+    def test_direct_pdf_url_unchanged(self):
+        """Direct PDF URLs should not be modified."""
+        url = 'https://example.com/paper.pdf'
+        if '-Abstract-Conference.html' in url:
+            pdf_url = url.replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
+        else:
+            pdf_url = url
+        assert pdf_url == 'https://example.com/paper.pdf'
+
+    def test_other_conference_url_unchanged(self):
+        """URLs from other conferences should not be modified."""
+        url = 'https://proceedings.mlr.press/v235/paper.pdf'
+        if '-Abstract-Conference.html' in url:
+            pdf_url = url.replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
+        else:
+            pdf_url = url
+        assert pdf_url == url

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -38,34 +38,54 @@ class TestScraperFetchTimeout:
         self._check_fetch_in_file('wacv_download_parse.py')
 
 
-class TestNipsAddPdftext:
-    """Test URL rewriting logic in nips_add_pdftext.py."""
+def _rewrite_neurips_url(url):
+    """Same logic as nips_download_parse.py and nips_add_pdftext.py."""
+    pdf_url = url
+    for abstract_suffix, paper_suffix in [
+        ('-Abstract-Conference.html', '-Paper-Conference.pdf'),
+        ('-Abstract-Datasets_and_Benchmarks.html', '-Paper-Datasets_and_Benchmarks.pdf'),
+        ('-Abstract.html', '-Paper.pdf'),
+    ]:
+        if abstract_suffix in pdf_url:
+            pdf_url = pdf_url.replace(abstract_suffix, paper_suffix).replace('/hash/', '/file/')
+            break
+    return pdf_url
 
-    def test_abstract_url_rewrite(self):
-        """Abstract URLs should be rewritten to PDF URLs."""
-        url = 'https://proceedings.neurips.cc/paper_files/paper/2024/hash/abc123-Abstract-Conference.html'
-        if '-Abstract-Conference.html' in url:
-            pdf_url = url.replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
-        else:
-            pdf_url = url
-        assert pdf_url.endswith('-Paper-Conference.pdf')
-        assert '/file/' in pdf_url
-        assert '/hash/' not in pdf_url
 
-    def test_direct_pdf_url_unchanged(self):
-        """Direct PDF URLs should not be modified."""
+class TestNeurIPSUrlRewrite:
+    """Test URL rewriting for all NeurIPS URL formats (3 patterns)."""
+
+    def test_new_format_conference(self):
+        """2021+ Conference track: -Abstract-Conference.html"""
+        url = 'https://proceedings.neurips.cc/paper_files/paper/2024/hash/abc-Abstract-Conference.html'
+        pdf = _rewrite_neurips_url(url)
+        assert pdf.endswith('-Paper-Conference.pdf')
+        assert '/file/' in pdf
+        assert '/hash/' not in pdf
+
+    def test_new_format_datasets(self):
+        """2021+ Datasets track: -Abstract-Datasets_and_Benchmarks.html"""
+        url = 'https://proceedings.neurips.cc/paper_files/paper/2023/hash/abc-Abstract-Datasets_and_Benchmarks.html'
+        pdf = _rewrite_neurips_url(url)
+        assert pdf.endswith('-Paper-Datasets_and_Benchmarks.pdf')
+        assert '/file/' in pdf
+
+    def test_old_format(self):
+        """2006-2020: -Abstract.html"""
+        url = 'https://proceedings.neurips.cc/paper_files/paper/2006/hash/abc-Abstract.html'
+        pdf = _rewrite_neurips_url(url)
+        assert pdf.endswith('-Paper.pdf')
+        assert '/file/' in pdf
+
+    def test_direct_pdf_unchanged(self):
         url = 'https://example.com/paper.pdf'
-        if '-Abstract-Conference.html' in url:
-            pdf_url = url.replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
-        else:
-            pdf_url = url
-        assert pdf_url == 'https://example.com/paper.pdf'
+        assert _rewrite_neurips_url(url) == url
 
-    def test_other_conference_url_unchanged(self):
-        """URLs from other conferences should not be modified."""
+    def test_other_conference_unchanged(self):
         url = 'https://proceedings.mlr.press/v235/paper.pdf'
-        if '-Abstract-Conference.html' in url:
-            pdf_url = url.replace('-Abstract-Conference.html', '-Paper-Conference.pdf').replace('/hash/', '/file/')
-        else:
-            pdf_url = url
-        assert pdf_url == url
+        assert _rewrite_neurips_url(url) == url
+
+    def test_no_double_rewrite(self):
+        """Already-rewritten URL should not be modified."""
+        url = 'https://proceedings.neurips.cc/paper_files/paper/2024/file/abc-Paper-Conference.pdf'
+        assert _rewrite_neurips_url(url) == url

--- a/uai_download_parse.py
+++ b/uai_download_parse.py
@@ -1,0 +1,83 @@
+"""
+Standalone helper script.
+
+Parses UAI proceedings from proceedings.mlr.press, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_uai.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+UAI_VOLUMES = {
+    115: 2019,
+    124: 2020,
+    161: 2021,
+    180: 2022,
+    216: 2023,
+    244: 2024,
+    286: 2025,
+}
+
+pubs = []
+warnings = []
+
+for vol, year in sorted(UAI_VOLUMES.items()):
+    url = "https://proceedings.mlr.press/v%d/" % (vol,)
+    print("downloading UAI %d (vol %d)..." % (year, vol))
+
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    try:
+        with urllib.request.urlopen(req) as f:
+            s = f.read()
+    except Exception as e:
+        print("error fetching vol %d: %s, skipping..." % (vol, e))
+        continue
+
+    print("done. Parsing...")
+    soup = BeautifulSoup(s, 'html.parser')
+
+    old_count = len(pubs)
+    venue = 'UAI %d' % (year,)
+
+    for paper_div in soup.find_all('div', {'class': 'paper'}):
+        new_pub = {}
+
+        title_tag = paper_div.find('p', {'class': 'title'})
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors_tag = paper_div.find('span', {'class': 'authors'})
+        if authors_tag:
+            authors_text = authors_tag.get_text()
+            authors = [a.strip().rstrip(';').strip() for a in authors_text.split(',')]
+            new_pub['authors'] = [a for a in authors if a]
+
+        links_tag = paper_div.find('p', {'class': 'links'})
+        if links_tag:
+            for a in links_tag.find_all('a'):
+                if 'Download PDF' in a.text:
+                    new_pub['pdf'] = a['href']
+                    break
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        pubs.append(new_pub)
+
+    print("read in %d publications for UAI %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_uai"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/uai_download_parse.py
+++ b/uai_download_parse.py
@@ -29,7 +29,7 @@ for vol, year in sorted(UAI_VOLUMES.items()):
 
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
     try:
-        with urllib.request.urlopen(req) as f:
+        with urllib.request.urlopen(req, timeout=30) as f:
             s = f.read()
     except Exception as e:
         print("error fetching vol %d: %s, skipping..." % (vol, e))

--- a/wacv_download_parse.py
+++ b/wacv_download_parse.py
@@ -1,0 +1,133 @@
+"""
+Standalone helper script.
+
+Parses WACV proceedings from openaccess.thecvf.com, creates list of
+dictionaries that store information about each publication, and saves
+the result as a pickle in current directory called pubs_wacv.
+"""
+
+import urllib.request
+from bs4 import BeautifulSoup
+from repool_util import savePubs
+
+BASE_URL = "https://openaccess.thecvf.com"
+
+
+def fetch(url):
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urllib.request.urlopen(req) as f:
+        return f.read()
+
+
+def get_pages_for_year(year):
+    if year <= 2020:
+        base = "%s/WACV%d.py" % (BASE_URL, year)
+    else:
+        base = "%s/WACV%d" % (BASE_URL, year)
+
+    try:
+        html = fetch(base + "?day=all")
+        soup = BeautifulSoup(html, 'html.parser')
+        if soup.find('dt', {'class': 'ptitle'}):
+            return [html]
+    except:
+        pass
+
+    try:
+        html = fetch(base)
+        soup = BeautifulSoup(html, 'html.parser')
+        pages = []
+        for a in soup.find_all('a'):
+            href = a.get('href', '')
+            if 'day=' in href and 'day=all' not in href:
+                day_url = BASE_URL + '/' + href.lstrip('/')
+                try:
+                    pages.append(fetch(day_url))
+                except:
+                    pass
+        if pages:
+            return pages
+    except:
+        pass
+
+    return []
+
+
+def parse_papers(html, venue, year):
+    soup = BeautifulSoup(html, 'html.parser')
+    results = []
+
+    for dt in soup.find_all('dt', {'class': 'ptitle'}):
+        new_pub = {}
+
+        title_tag = dt.find('a')
+        if not title_tag:
+            continue
+
+        new_pub['title'] = title_tag.text.strip()
+
+        authors = []
+        for dd in dt.find_next_siblings('dd'):
+            if dd.find_previous_sibling('dt', {'class': 'ptitle'}) != dt:
+                break
+
+            for form in dd.find_all('form', {'class': 'authsearch'}):
+                author_input = form.find('input', {'name': 'query_author'})
+                if not author_input:
+                    author_input = form.find('input', {'name': 'query'})
+                if author_input:
+                    authors.append(author_input['value'])
+
+            for a in dd.find_all('a'):
+                href = a.get('href', '')
+                if href.endswith('.pdf') and 'supp' not in href.lower():
+                    new_pub['pdf'] = BASE_URL + '/' + href.lstrip('/')
+                    break
+
+        if authors:
+            new_pub['authors'] = authors
+
+        new_pub['venue'] = venue
+        new_pub['year'] = year
+        results.append(new_pub)
+
+    return results
+
+
+pubs = []
+warnings = []
+
+for year in range(2020, 2027):
+    print("downloading WACV %d..." % (year,))
+
+    try:
+        pages = get_pages_for_year(year)
+    except Exception as e:
+        print("error fetching year %d: %s, skipping..." % (year, e))
+        continue
+
+    if not pages:
+        warnings.append("no pages found for WACV %d" % (year,))
+        print("no data found, skipping...")
+        continue
+
+    venue = 'WACV %d' % (year,)
+    old_count = len(pubs)
+
+    for page_html in pages:
+        pubs.extend(parse_papers(page_html, venue, year))
+
+    print("read in %d publications for WACV %d." % (len(pubs) - old_count, year))
+
+if len(warnings) > 0:
+    print("%d warnings:" % (len(warnings),))
+    for x in warnings:
+        print(x)
+else:
+    print("No warnings generated.")
+
+print("read in a total of %d publications." % (len(pubs),))
+fname = "pubs_wacv"
+print("saving pickle in %s" % (fname,))
+savePubs(fname, pubs)
+print("all done.")

--- a/wacv_download_parse.py
+++ b/wacv_download_parse.py
@@ -15,7 +15,7 @@ BASE_URL = "https://openaccess.thecvf.com"
 
 def fetch(url):
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-    with urllib.request.urlopen(req) as f:
+    with urllib.request.urlopen(req, timeout=30) as f:
         return f.read()
 
 
@@ -30,7 +30,7 @@ def get_pages_for_year(year):
         soup = BeautifulSoup(html, 'html.parser')
         if soup.find('dt', {'class': 'ptitle'}):
             return [html]
-    except:
+    except Exception:
         pass
 
     try:
@@ -43,11 +43,11 @@ def get_pages_for_year(year):
                 day_url = BASE_URL + '/' + href.lstrip('/')
                 try:
                     pages.append(fetch(day_url))
-                except:
+                except Exception:
                     pass
         if pages:
             return pages
-    except:
+    except Exception:
         pass
 
     return []


### PR DESCRIPTION
## Summary

Full Python 3 migration of the original codebase plus 35 new scrapers covering all major open-access AI/ML/NLP/CV conferences. Total: **214,222 papers** from **36 conferences** across **12 sources**.

## Python 3 Migration

- `cPickle` -> `pickle`, `cStringIO` -> `io`, `file()` -> `open()`
- `print` statements -> `print()` functions
- `dict.has_key()` -> `'key' in dict`
- `urllib` -> `urllib.request` / `urllib.parse`
- `BeautifulSoup` v3 -> `beautifulsoup4` (bs4)
- `os.startfile` (Windows-only) -> `webbrowser.open` (cross-platform)
- PDFMiner old API (`process_pdf`) -> `pdfminer.six` (`extract_text`)
- `google_search.py`: replaced dead Google AJAX API
- `nips_download_parse.py`: updated to `proceedings.neurips.cc`, dynamic year range
- Fixed `dictionary changed size during iteration` bug in `stringToWordDictionary`
- Fixed missing comma in stopwords list (`'those'` + `'may'` were concatenated)
- Binary mode for pickle files (`wb`/`rb`)
- Added `requirements.txt` with `beautifulsoup4` and `pdfminer.six`
- Added `.gitignore`

## New Scrapers (35 conferences)

All scrapers follow the same pattern as the original `nips_download_parse.py`: fetch proceedings HTML, parse with BeautifulSoup, save as pickle.

| Conference | Source | Years | Papers |
|---|---|---|---|
| NeurIPS | proceedings.neurips.cc | 2006-2024 | 21,859 |
| ACL | aclanthology.org | 2000-2025 | 21,490 |
| EMNLP | aclanthology.org | 2000-2025 | 20,646 |
| CVPR | openaccess.thecvf.com | 2013-2025 | 18,452 |
| AAAI | ojs.aaai.org | 2019-2025 | 15,097 |
| ICML | proceedings.mlr.press | 2013-2025 | 14,281 |
| ICLR | openreview.net | 2018-2025 | 11,015 |
| IJCAI | ijcai.org | 2013-2025 | 9,940 |
| ICCV | openaccess.thecvf.com | 2013-2025 | 9,145 |
| NAACL | aclanthology.org | 2000-2025 | 8,925 |
| INTERSPEECH | isca-archive.org | 2016-2024 | 8,785 |
| COLING | aclanthology.org | 2000-2025 | 8,740 |
| ECCV | ecva.net | 2018-2024 | 6,166 |
| IJCNLP | aclanthology.org | 2005-2025 | 5,337 |
| AISTATS | proceedings.mlr.press | 2010-2025 | 4,613 |
| WACV | openaccess.thecvf.com | 2020-2026 | 4,435 |
| JMLR | jmlr.org | 2000-2025 | 4,135 |
| SemEval | aclanthology.org | 2007-2025 | 3,217 |
| EACL | aclanthology.org | 2003-2024 | 3,138 |
| MICCAI | papers.miccai.org | 2024-2025 | 1,883 |
| COLT | proceedings.mlr.press | 2011-2025 | 1,598 |
| CoNLL | aclanthology.org | 2000-2025 | 1,547 |
| CoRL | proceedings.mlr.press | 2017-2025 | 1,490 |
| RSS | roboticsproceedings.org | 2005-2025 | 1,469 |
| UAI | proceedings.mlr.press | 2019-2025 | 1,368 |
| AACL | aclanthology.org | 2020-2025 | 938 |
| ACML | proceedings.mlr.press | 2010-2024 | 834 |
| NSDI | usenix.org | 2012-2025 | 821 |
| L4DC | proceedings.mlr.press | 2020-2025 | 669 |
| MIDL | proceedings.mlr.press | 2019-2024 | 504 |
| OSDI | usenix.org | 2012-2025 | 472 |
| ALT | proceedings.mlr.press | 2017-2025 | 381 |
| MLHC | proceedings.mlr.press | 2016-2025 | 323 |
| PGM | proceedings.mlr.press | 2016-2024 | 222 |
| CLeaR | proceedings.mlr.press | 2022-2025 | 190 |
| AutoML | proceedings.mlr.press | 2016-2025 | 97 |
| **Total** | | | **214,222** |

## Test plan

- [x] All Python files compile under Python 3.10
- [x] All 36 scrapers run successfully and produce valid pickle files
- [x] `loadPubs` / `savePubs` work with new binary pickle format
- [x] `stringToWordDictionary` no longer crashes (dict iteration fix)
- [x] PDF extraction pipeline (stage 2+3) works end-to-end
- [x] Cross-conference queries work on combined 214k dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)